### PR TITLE
Add OpenAPI spec generation and HTTP endpoints "/openapi.json" and "/openapi.yaml"

### DIFF
--- a/platform/alarms/rest/pom.xml
+++ b/platform/alarms/rest/pom.xml
@@ -51,7 +51,10 @@
       <artifactId>rest</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/platform/alarms/rest/src/main/java/org/opennms/netmgt/alarmd/rest/internal/AlarmRestServiceImpl.java
+++ b/platform/alarms/rest/src/main/java/org/opennms/netmgt/alarmd/rest/internal/AlarmRestServiceImpl.java
@@ -53,6 +53,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.opennms.horizon.core.lib.SystemProperties;
 import org.opennms.horizon.db.dao.api.AlarmDao;
 import org.opennms.horizon.db.dao.api.SessionUtils;
@@ -170,6 +171,9 @@ public class AlarmRestServiceImpl implements AlarmRestService {
     @GET
     @Path("list")
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
+    @ApiResponse(
+            description = "Retrieve the list of alarms"
+    )
     public Response getAlarms(@Context final SecurityContext securityContext, @Context final UriInfo uriInfo) {
         // replace the next line with @RolesAllowed("")
         //SecurityHelper.assertUserReadCredentials(securityContext);
@@ -197,6 +201,9 @@ public class AlarmRestServiceImpl implements AlarmRestService {
     @PUT
     @Path("{id}/memo")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @ApiResponse(
+            description = "Update the memo for an Alarm"
+    )
     public Response updateMemo(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
         // replace the next two lines with @RolesAllowed("")
         final String user = params.containsKey("user") ? params.getFirst("user") : securityContext.getUserPrincipal().getName();
@@ -215,6 +222,9 @@ public class AlarmRestServiceImpl implements AlarmRestService {
     @PUT
     @Path("{id}/journal")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @ApiResponse(
+            description = "Update the journal for an Alarm"
+    )
     public Response updateJournal(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId, final MultivaluedMapImpl params) {
         return this.sessionUtils.withTransaction(() -> {
             final String user = params.containsKey("user") ? params.getFirst("user") : securityContext.getUserPrincipal().getName();
@@ -228,6 +238,9 @@ public class AlarmRestServiceImpl implements AlarmRestService {
 
     @DELETE
     @Path("{id}/memo")
+    @ApiResponse(
+            description = "Remove the memo for an Alarm"
+    )
     public Response removeMemo(@Context final SecurityContext securityContext, @PathParam("id") final Integer alarmId) {
         //SecurityHelper.assertUserEditCredentials(securityContext, securityContext.getUserPrincipal().getName());
         try {

--- a/platform/alarms/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/alarms/rest/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -49,4 +49,15 @@
             <entry key="osgi.jaxrs.resource" value="true"/>
         </service-properties>
     </service>
+
+    <!--                 -->
+    <!-- OPEN API WIRING -->
+    <!--                 -->
+    <bean id="openApiInfo" class="io.swagger.v3.oas.models.info.Info">
+        <property name="title" value="OpenNMS Alarms Rest Service"/>
+    </bean>
+    <bean id="openApi" class="io.swagger.v3.oas.models.OpenAPI">
+        <property name="info" ref="openApiInfo"/>
+    </bean>
+    <service ref="openApi" auto-export="all-classes"/>
 </blueprint>

--- a/platform/assemblies/features/src/main/feature/features.xml
+++ b/platform/assemblies/features/src/main/feature/features.xml
@@ -19,7 +19,7 @@
 
         <bundle>mvn:org.opennms.horizon.alarms/api/${project.version}</bundle>
         <bundle>mvn:org.opennms.horizon.alarms/daemon/${project.version}</bundle>
-        <bundle>mvn:org.opennms.horizon.alarms/rest/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.opennms.horizon.alarms/rest/${project.version}</bundle>
     </feature>
 
     <feature name="horizon-core" version="${project.version}">
@@ -38,11 +38,13 @@
     <feature name="horizon-core-rest" version="${project.version}">
         <feature>horizon-core</feature>
 
-        <feature>http</feature>
-        <feature>jetty</feature>
+        <feature>cxf</feature>
         <feature>cxf-jaxrs</feature>
         <feature>cxf-sse</feature>
+        <feature>cxf-rs-description-openapi-v3</feature>
+
         <bundle>mvn:org.apache.aries.component-dsl/org.apache.aries.component-dsl.component-dsl/1.2.2</bundle>
+        <bundle>mvn:org.apache.aries.jax.rs/org.apache.aries.jax.rs.openapi.resource/${aries.jax.rs.whiteboard.version}</bundle>
         <feature>aries-jax-rs-whiteboard</feature>
         <feature>aries-jax-rs-whiteboard-jackson</feature>
         <bundle>mvn:javax.annotation/javax.annotation-api/1.3.2</bundle>
@@ -51,7 +53,7 @@
 <!--        <feature>jaas-deployer</feature>-->
 <!--        <bundle>mvn:org.opennms.horizon.core/jaas/${project.version}</bundle>-->
 
-        <bundle>mvn:org.opennms.horizon.core/rest/${project.version}</bundle>
+        <bundle start-level="79">mvn:org.opennms.horizon.core/rest/${project.version}</bundle>
     </feature>
 
     <!-- WORKAROUND: the PooledDataSourceFactory service exported by pax-jdbc-pool-hikaricp for some reason -->
@@ -104,7 +106,7 @@
 
         <bundle>mvn:org.opennms.horizon.events/dao/${project.version}</bundle>
         <bundle>mvn:org.opennms.horizon.events/daemon/${project.version}</bundle>
-        <bundle>mvn:org.opennms.horizon.events/rest/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.opennms.horizon.events/rest/${project.version}</bundle>
         <bundle>mvn:org.opennms.horizon.events/shell/${project.version}</bundle>
     </feature>
 

--- a/platform/bom/pom.xml
+++ b/platform/bom/pom.xml
@@ -137,6 +137,11 @@
                 <version>${opentracing.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>${swagger.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>jakarta.xml.bind</groupId>
                 <artifactId>jakarta.xml.bind-api</artifactId>
                 <version>${jakarta.xml.version}</version>

--- a/platform/core/rest/pom.xml
+++ b/platform/core/rest/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-service-description-openapi-v3</artifactId>
+            <version>${cxf.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/platform/docker-it/src/test/resources/org/opennms/horizon/openapi-spec.feature
+++ b/platform/docker-it/src/test/resources/org/opennms/horizon/openapi-spec.feature
@@ -1,0 +1,44 @@
+Feature: OpenNMS OpenAPI Specification export via
+
+  Scenario: Verify the Alarms Rest Service entry in the OpenAPI Specification
+    Given application base url in system property "application.base-url"
+    Given http username "admin" password "admin"
+    Given JSON accept encoding
+    Then send GET request at path "/openapi.json" with retry timeout 20000
+    Then DEBUG dump the response body
+    Then parse the JSON response
+    Then verify JSON path expressions match
+      | openapi == 3.0.1                                                                                               |
+    Then verify JSON path expressions match
+      | paths["/alarms/list"]["get"]["operationId"] == getAlarms                                                       |
+      | paths["/alarms/list"]["get"]["responses"]["default"]["description"] == Retrieve the list of alarms             |
+      | paths["/alarms/{id}/memo"]["put"]["operationId"] == updateMemo                                                 |
+      | paths["/alarms/{id}/memo"]["put"]["responses"]["default"]["description"] == Update the memo for an Alarm       |
+      | paths["/alarms/{id}/memo"]["delete"]["operationId"] == removeMemo                                              |
+      | paths["/alarms/{id}/memo"]["delete"]["responses"]["default"]["description"] == Remove the memo for an Alarm    |
+      | paths["/alarms/{id}/journal"]["put"]["operationId"] == updateJournal                                           |
+      | paths["/alarms/{id}/journal"]["put"]["responses"]["default"]["description"] == Update the journal for an Alarm |
+
+  Scenario: Verify the Events Rest Service entry in the OpenAPI Specification
+    Given application base url in system property "application.base-url"
+    Given http username "admin" password "admin"
+    Given JSON accept encoding
+    Then send GET request at path "/openapi.json" with retry timeout 20000
+    Then DEBUG dump the response body
+    Then parse the JSON response
+    Then verify JSON path expressions match
+      | paths["/events/count"]["get"]["operationId"] == getCount                                                                                 |
+      | paths["/events/count"]["get"]["responses"]["default"]["description"] == Retrieve the count of events                                     |
+      | paths["/events/{eventId}"]["get"]["operationId"] == getEvent                                                                             |
+      | paths["/events/{eventId}"]["get"]["responses"]["default"]["description"] == Retrieve an event by ID                                      |
+      | paths["/events/{eventId}"]["put"]["operationId"] == updateEvent                                                                          |
+      | paths["/events/{eventId}"]["put"]["responses"]["default"]["description"] ==  Update the ACK state of an event                            |
+      | paths["/events"]["get"]["operationId"] == getEvents                                                                                      |
+      | paths["/events"]["get"]["responses"]["default"]["description"] ==  Retrieve a list of events                                             |
+      | paths["/events"]["put"]["operationId"] == updateEvents                                                                                   |
+      | paths["/events"]["put"]["responses"]["default"]["description"] ==  Update the ACK state of events that match filter/query criteria given |
+      | paths["/events"]["post"]["operationId"] == publishEvent                                                                                  |
+      | paths["/events"]["post"]["responses"]["default"]["description"] ==   Publish a new event                                                 |
+      | paths["/events/between"]["get"]["operationId"] == getEventsBetween                                                                       |
+      | paths["/events/between"]["get"]["responses"]["default"]["description"] == Retrieve a list of events in the specified date range          |
+

--- a/platform/events/api/src/main/java/org/opennms/horizon/events/xml/AlarmData.java
+++ b/platform/events/api/src/main/java/org/opennms/horizon/events/xml/AlarmData.java
@@ -336,14 +336,7 @@ public class AlarmData implements Serializable {
         }
         return hasFields;
     }
-    
-    public void setUpdateField(UpdateField[] fields) {
-        m_updateFieldList.clear();
-        for (int i = 0; i < fields.length; i++) {
-            m_updateFieldList.add(fields[i]);
-        }
-    }
-    
+
     public void setUpdateField(final List<UpdateField> fields) {
         if (m_updateFieldList == fields) return;
         m_updateFieldList.clear();

--- a/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Correlation.java
+++ b/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Correlation.java
@@ -374,21 +374,6 @@ public class Correlation implements Serializable {
     }
 
     /**
-     * 
-     * 
-     * @param vCueiArray
-     */
-    public void setCuei(
-            final String[] vCueiArray) {
-        //-- copy array
-        _cueiList.clear();
-        
-        for (int i = 0; i < vCueiArray.length; i++) {
-                this._cueiList.add(vCueiArray[i]);
-        }
-    }
-
-    /**
      * Sets the value of '_cueiList' by copying the given Vector.
      * All elements will be checked for type safety.
      * 

--- a/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Event.java
+++ b/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Event.java
@@ -1365,20 +1365,6 @@ public class Event implements Message,Serializable {
 	}
 
 	/**
-	 * 
-	 * 
-	 * @param vAutoactionArray
-	 */
-	public void setAutoaction(final Autoaction[] vAutoactionArray) {
-		// -- copy array
-		_autoactionList.clear();
-
-		for (int i = 0; i < vAutoactionArray.length; i++) {
-			_autoactionList.add(vAutoactionArray[i]);
-		}
-	}
-
-	/**
 	 * Sets the value of '_autoactionList' by copying the given Vector. All
 	 * elements will be checked for type safety.
 	 * 
@@ -1477,20 +1463,6 @@ public class Event implements Message,Serializable {
 	}
 
 	/**
-	 * 
-	 * 
-	 * @param vForwardArray
-	 */
-	public void setForward(final Forward[] vForwardArray) {
-		// -- copy array
-		_forwardList.clear();
-
-		for (int i = 0; i < vForwardArray.length; i++) {
-			_forwardList.add(vForwardArray[i]);
-		}
-	}
-
-	/**
 	 * Sets the value of '_forwardList' by copying the given Vector. All
 	 * elements will be checked for type safety.
 	 * 
@@ -1578,20 +1550,6 @@ public class Event implements Message,Serializable {
 		}
 
 		_loggroupList.set(index, vLoggroup);
-	}
-
-	/**
-	 * 
-	 * 
-	 * @param vLoggroupArray
-	 */
-	public void setLoggroup(final String[] vLoggroupArray) {
-		// -- copy array
-		_loggroupList.clear();
-
-		for (int i = 0; i < vLoggroupArray.length; i++) {
-			_loggroupList.add(vLoggroupArray[i]);
-		}
 	}
 
 	/**
@@ -1695,20 +1653,6 @@ public class Event implements Message,Serializable {
 	}
 
 	/**
-	 * 
-	 * 
-	 * @param vOperactionArray
-	 */
-	public void setOperaction(final Operaction[] vOperactionArray) {
-		// -- copy array
-		_operactionList.clear();
-
-		for (int i = 0; i < vOperactionArray.length; i++) {
-			_operactionList.add(vOperactionArray[i]);
-		}
-	}
-
-	/**
 	 * Sets the value of '_operactionList' by copying the given Vector. All
 	 * elements will be checked for type safety.
 	 * 
@@ -1780,20 +1724,6 @@ public class Event implements Message,Serializable {
 		}
 
 		_scriptList.set(index, vScript);
-	}
-
-	/**
-	 * 
-	 * 
-	 * @param vScriptArray
-	 */
-	public void setScript(final Script[] vScriptArray) {
-		// -- copy array
-		_scriptList.clear();
-
-		for (int i = 0; i < vScriptArray.length; i++) {
-			_scriptList.add(vScriptArray[i]);
-		}
 	}
 
 	/**

--- a/platform/events/api/src/main/java/org/opennms/horizon/events/xml/EventReceipt.java
+++ b/platform/events/api/src/main/java/org/opennms/horizon/events/xml/EventReceipt.java
@@ -234,21 +234,6 @@ public class EventReceipt implements Serializable {
     }
 
     /**
-     * 
-     * 
-     * @param vUuidArray
-     */
-    public void setUuid(
-            final String[] vUuidArray) {
-        //-- copy array
-        _uuidList.clear();
-        
-        for (int i = 0; i < vUuidArray.length; i++) {
-                this._uuidList.add(vUuidArray[i]);
-        }
-    }
-
-    /**
      * Sets the value of '_uuidList' by copying the given Vector.
      * All elements will be checked for type safety.
      * 

--- a/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Mask.java
+++ b/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Mask.java
@@ -256,21 +256,6 @@ public class Mask implements Serializable {
     }
 
     /**
-     * 
-     * 
-     * @param vMaskelementArray
-     */
-    public void setMaskelement(
-            final Maskelement[] vMaskelementArray) {
-        //-- copy array
-        _maskelementList.clear();
-        
-        for (int i = 0; i < vMaskelementArray.length; i++) {
-                this._maskelementList.add(vMaskelementArray[i]);
-        }
-    }
-
-    /**
      * Sets the value of '_maskelementList' by copying the given
      * Vector. All elements will be checked for type safety.
      * 

--- a/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Maskelement.java
+++ b/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Maskelement.java
@@ -284,21 +284,6 @@ public class Maskelement implements Serializable {
     }
 
     /**
-     * 
-     * 
-     * @param vMevalueArray
-     */
-    public void setMevalue(
-            final String[] vMevalueArray) {
-        //-- copy array
-        _mevalueList.clear();
-        
-        for (int i = 0; i < vMevalueArray.length; i++) {
-                this._mevalueList.add(vMevalueArray[i].intern());
-        }
-    }
-
-    /**
      * Sets the value of '_mevalueList' by copying the given
      * Vector. All elements will be checked for type safety.
      * 

--- a/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Parms.java
+++ b/platform/events/api/src/main/java/org/opennms/horizon/events/xml/Parms.java
@@ -243,21 +243,6 @@ public class Parms implements Serializable {
     }
 
     /**
-     * 
-     * 
-     * @param vParmArray
-     */
-    public void setParm(
-            final Parm[] vParmArray) {
-        //-- copy array
-        _parmList.clear();
-        
-        for (int i = 0; i < vParmArray.length; i++) {
-                this._parmList.add(vParmArray[i]);
-        }
-    }
-
-    /**
      * Sets the value of '_parmList' by copying the given Vector.
      * All elements will be checked for type safety.
      * 

--- a/platform/events/daemon/src/main/java/org/opennms/netmgt/eventd/EventExpander.java
+++ b/platform/events/daemon/src/main/java/org/opennms/netmgt/eventd/EventExpander.java
@@ -29,6 +29,7 @@
 package org.opennms.netmgt.eventd;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -426,7 +427,7 @@ public final class EventExpander implements org.opennms.horizon.events.api.Event
         }
 
         if (expanded) {
-            event.setAutoaction(autoactions);
+            event.setAutoaction(Arrays.asList(autoactions));
         }
     }
 
@@ -445,7 +446,7 @@ public final class EventExpander implements org.opennms.horizon.events.api.Event
         }
 
         if (expanded) {
-            event.setOperaction(operactions);
+            event.setOperaction(Arrays.asList(operactions));
         }
     }
 

--- a/platform/events/rest/src/main/java/org/opennms/netmgt/events/rest/internal/EventRestServiceImpl.java
+++ b/platform/events/rest/src/main/java/org/opennms/netmgt/events/rest/internal/EventRestServiceImpl.java
@@ -58,6 +58,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.opennms.horizon.db.dao.api.EventDao;
@@ -152,6 +153,9 @@ public class EventRestServiceImpl implements EventRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("{eventId}")
+    @ApiResponse(
+            description = "Retrieve an event by ID"
+    )
     public EventDTO getEvent(@PathParam("eventId") Integer eventId) {
         Supplier<EventDTO> op = () -> {
             OnmsEvent onmsEvent = this.lookupRequiredEvent(eventId);
@@ -171,6 +175,9 @@ public class EventRestServiceImpl implements EventRestService {
     @Produces(MediaType.TEXT_PLAIN)
     @Path("count")
     // @RolesAllowed({"user", "admin"})
+    @ApiResponse(
+            description = "Retrieve the count of events"
+    )
     public String getCount() {
         return Long.toString(m_eventDao.countAll());
     }
@@ -186,6 +193,9 @@ public class EventRestServiceImpl implements EventRestService {
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @RolesAllowed({"user", "admin"})
+    @ApiResponse(
+            description = "Retrieve a list of events"
+    )
     public EventCollectionDTO getEvents(@Context final UriInfo uriInfo) throws ParseException {
         CriteriaBuilder builder = getCriteriaBuilder(uriInfo.getQueryParameters());
         return this.sessionUtils.withReadOnlyTransaction(
@@ -204,6 +214,9 @@ public class EventRestServiceImpl implements EventRestService {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     @Path("between")
     // @RolesAllowed({"user", "admin"})
+    @ApiResponse(
+            description = "Retrieve a list of events in the specified date range"
+    )
     public EventCollectionDTO getEventsBetween(@Context UriInfo uriInfo) throws ParseException {
         MultivaluedMap<String, String> params = uriInfo.getQueryParameters();
 
@@ -226,6 +239,9 @@ public class EventRestServiceImpl implements EventRestService {
     @Path("{eventId}")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     // @RolesAllowed({"admin"})
+    @ApiResponse(
+            description = "Update the ACK state of an event"
+    )
     public Response updateEvent(@Context SecurityContext securityContext, @PathParam("eventId") Integer eventId, @FormParam("ack") Boolean ack) {
         if (ack == null) {
             throw new WebApplicationException(
@@ -253,6 +269,9 @@ public class EventRestServiceImpl implements EventRestService {
     @PUT
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     // @RolesAllowed({"admin"})
+    @ApiResponse(
+            description = "Update the ACK state of events that match filter/query criteria given"
+    )
     public Response updateEvents(@Context SecurityContext securityContext, MultivaluedHashMap<String, String> formProperties) {
         /*
         Boolean ack = false;
@@ -276,6 +295,9 @@ public class EventRestServiceImpl implements EventRestService {
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON, MediaType.APPLICATION_ATOM_XML})
     // @RolesAllowed({"admin"})
+    @ApiResponse(
+            description = "Publish a new event"
+    )
     public Response publishEvent(final Event event) {
         if (event.getSource() == null) {
             event.setSource("ReST");

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -36,7 +36,7 @@
         <commons.io.version>2.8.0</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>
         <cucumber.version>7.1.0</cucumber.version>
-        <cxf.version>3.4.5</cxf.version>
+        <cxf.version>3.5.0</cxf.version>
         <drools.version>7.31.0.Final</drools.version>
         <glassfish.jaxb.version>2.3.2</glassfish.jaxb.version>
         <grpc.version>1.43.2</grpc.version>
@@ -80,6 +80,7 @@
         <snmp4j.version>2.5.5</snmp4j.version>
         <snmp4j.agent.version>2.5.3</snmp4j.agent.version>
         <spring.version>4.2.9.RELEASE_1</spring.version>
+        <swagger.version>2.1.1</swagger.version>
         <testcontainers.version>1.16.3</testcontainers.version>
     </properties>
 


### PR DESCRIPTION
- Set start-level for CORE REST below other REST to ensure whiteboard extensions take effect.
- Update CXF to 3.5.0 to resolve javax.api vs jakarta.servlet-api issue.
- Remove helper setters causing Jackson to fail marshalling with "Conflicting setter definitions" error.