### PR TITLE
check process.env before vite.env to use vars passed through cmd line

### DIFF
--- a/ui/keycloak.config.ts
+++ b/ui/keycloak.config.ts
@@ -1,5 +1,5 @@
 export default {
-  realm: import.meta.env.VITE_KEYCLOAK_REALM,
-  url: import.meta.env.VITE_KEYCLOAK_URL,
-  clientId: import.meta.env.VITE_KEYCLOAK_CLIENT_ID
+  realm: process.env.KEYCLOAK_REALM || import.meta.env.VITE_KEYCLOAK_REALM,
+  url: process.env.KEYCLOAK_URL || import.meta.env.VITE_KEYCLOAK_URL,
+  clientId: process.env.KEYCLOAK_CLIENT_ID || import.meta.env.VITE_KEYCLOAK_CLIENT_ID
 }

--- a/ui/src/services/axiosInstances.ts
+++ b/ui/src/services/axiosInstances.ts
@@ -3,7 +3,7 @@ import useToken from '@/composables/useToken'
 import { refreshToken } from './authService'
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_BASE_URL?.toString() || '/opennms/api'
+  baseURL: process.env.API_BASE_URL || import.meta.env.VITE_BASE_URL?.toString()
 })
 
 api.interceptors.request.use(


### PR DESCRIPTION
## JIRA Link
https://issues.opennms.org/browse/HS-73

## Details of the change
Can now use cross-env to pass in env vars through cmd line
