### PR TITLE
Fixing bad blueprint wiring

### DIFF
--- a/platform/provision/snmp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/provision/snmp/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -9,10 +9,9 @@
 		http://aries.apache.org/schemas/blueprint-ext/blueprint-ext-1.5.xsd
 ">
 
-	<bean id="snmpDetector" class="org.opennms.netmgt.provision.detector.snmp.SnmpDetector" destroy-method="destroy" />
 
 	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">
-		<ref component-id="snmpDetector" />
+		<bean class="org.opennms.netmgt.provision.detector.snmp.SnmpDetectorFactory" />
 	</service>
 
 	<service interface="org.opennms.netmgt.provision.ServiceDetectorFactory">


### PR DESCRIPTION
## JIRA Link
https://issues.opennms.org/browse/HS-xx

## Checklist
* [ ] JIRA has been updated to 'in review'.
* [ ] Unit tests have been added as part of the PR.
* [ ] Manual tests have been completed, and notes added to JIRA.
* [ ] Details have been provided to docs team (if necessary)
* [ ] Screenshot(s) included (applicable to changes with a visual impact).

## Details of the change

The SNMP detector bundle was not starting due to some bad blueprint wiring. This corrects it.
