### PR TITLE
HS-188: Minion location should be Default

### DIFF
--- a/dev/kubernetes.kafka.yaml
+++ b/dev/kubernetes.kafka.yaml
@@ -627,7 +627,7 @@ data:
   minion-config.yaml: |
     http-url: "http://horizon:8980/opennms"
     id: "minion-01"
-    location: "minion-location"
+    location: "Default"
     
     karaf:
       shell:


### PR DESCRIPTION
## Description
Update minion location to `Default`

## Jira link(s)
- https://issues.opennms.org/browse/HS-188


## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
