### PR TITLE
HS-198 Add Grafana into Dev environment

### DIFF
--- a/dev/kubernetes.kafka.yaml
+++ b/dev/kubernetes.kafka.yaml
@@ -181,6 +181,48 @@ spec:
   selector:
     run: prometheus-pushgateway
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    run: grafana
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      name: grafana-http
+  selector:
+    run: grafana
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  selector:
+    matchLabels:
+      run: grafana
+  template:
+    metadata:
+      labels:
+        run: grafana
+    spec:
+      volumes:
+        - name: hs-grafana-ds
+          configMap:
+            name: grafana-datasource-config
+      containers:
+        - name: grafana
+          image: grafana/grafana
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: hs-grafana-ds
+              mountPath: "/etc/grafana/provisioning/datasources/default.yml"
+              subPath: "default.yml"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -668,6 +710,30 @@ spec:
               value: "http://localhost:28080"
           command: ["/app/dev/entrypoint.sh"]
           args: ["$(DOMAIN_KEYCLOAK)","$(DOMAIN_API)"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasource-config
+data:
+  default.yml: |
+    apiVersion: 1
+    
+    datasources:
+      - name: hs-metrics
+        type: prometheus
+        access: proxy
+        orgId: 1
+        url: http://prometheus:9090
+        isDefault: false
+        jsonData:
+          httpHeaderName1: "X-Scope-OrgID"
+        ## <string> json object of data that will be encrypted.
+        secureJsonData:
+          httpHeaderValue1: "{{ .Values.Namespace }}"
+        version: 1
+        # <bool> allow users to edit datasources from the UI.
+        editable: false
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -92,6 +92,10 @@ portForward:
     resourceName: prometheus-pushgateway
     port: 9091 #prometheus-pushgateway tcp
     localPort: 59091
+  - resourceType: deployment
+    resourceName: grafana
+    port: 3000 #grafana HTTP
+    localPort: 53000
 deploy:
   kubectl:
     manifests:


### PR DESCRIPTION
## Description
Start skaffold and wait until all pods running. login http://localhost:53000/ as admin/admin and verify datasources hs-metrics is created. Using the following shell script can simulate some sample data. 
```#!/bin/bash
for i in {1..1000}
do
    echo "some_metric ${RANDOM:0:2}" | curl --data-binary @- http://localhost:59091/metrics/job/some_job
    sleep 120
done
```

Wait for few minutes then can query from the hs-metrics datasource and create an sample dashboard




## Jira link(s)
- https://issues.opennms.org/browse/HS-198

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
