### PR TITLE
Jira/hs 268 latest ds data

### DIFF
--- a/keycloak-ui/Dockerfile
+++ b/keycloak-ui/Dockerfile
@@ -1,5 +1,5 @@
 # After testing, version 18 and 17.0.1 works on M1 MacBook, for more information https://github.com/keycloak/keycloak/issues/8825
-FROM quay.io/keycloak/keycloak:18.0.0
+FROM quay.io/keycloak/keycloak:19.0.1
 
 USER 0
 


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Add GraphQL to retrieve TS data from Prometheus server
For minion:
- minion_uptime_sec
- minion_response_time_msec
For device:
- snmp_uptime_sec
- icmp_round_trip_time_msec

Add one device with localhost and test in GraphQL playground at http://localhost:9090/gui 

## Jira link(s)
- https://issues.opennms.org/browse/HS-268

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
