### PR TITLE
HS-303: Add groupingKeys for push gateway

### DIFF
--- a/platform/ipc/echo/src/main/java/org/opennms/horizon/echo/monitor/SimpleMinionRpcMonitor.java
+++ b/platform/ipc/echo/src/main/java/org/opennms/horizon/echo/monitor/SimpleMinionRpcMonitor.java
@@ -29,6 +29,7 @@
 package org.opennms.horizon.echo.monitor;
 
 import com.google.common.base.Strings;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
 import org.opennms.horizon.core.lib.InetAddressUtils;
 import org.opennms.horizon.echo.EchoRequest;
@@ -41,15 +42,23 @@ import org.opennms.horizon.metrics.api.OnmsMetricsAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class SimpleMinionRpcMonitor {
 
     private final static int DEFAULT_MESSAGE_SIZE = 1024;
 
     private static final Logger LOG = LoggerFactory.getLogger(SimpleMinionRpcMonitor.class);
+
+    private static final String[] labelNames = {"instance", "location"};
+
+    private final CollectorRegistry collectorRegistry = new CollectorRegistry();
+
+    private final Gauge responseTimeGauge = Gauge.build().name("minion_response_time").help("Response time of Minion RPC")
+        .unit("msec").labelNames(labelNames).register(collectorRegistry);
 
     private RpcClientFactory rpcClientFactory;
 
@@ -155,16 +164,16 @@ public class SimpleMinionRpcMonitor {
             EchoResponse response = client.execute(request).get();
             long responseTime = ( System.nanoTime() / 1000000 ) - response.getId();
             LOG.info("ECHO RESPONSE: node-id={}; node-location={}; duration={}ms", nodeId, nodeLocation, responseTime);
-            updateMetrics(responseTime, nodeId, nodeLocation);
+            updateMetrics(responseTime, new String[]{nodeId, nodeLocation});
         } catch (InterruptedException|ExecutionException t) {
             LOG.warn("ECHO REQUEST failed", t);
         }
     }
 
-    private void updateMetrics(long responseTime, String... labelValues) {
-        Gauge responseTimeGauge = Gauge.build().name("minion_response_time").help("Response time of Minion RPC")
-            .unit("msec").labelNames("instance", "location").create();
+    private void updateMetrics(long responseTime, String[] labelValues) {
         responseTimeGauge.labels(labelValues).set(responseTime);
-        metricsAdapter.push(responseTimeGauge);
+        var groupingKey = IntStream.range(0, labelNames.length).boxed()
+            .collect(Collectors.toMap(i -> labelNames[i], i -> labelValues[i]));
+        metricsAdapter.pushRegistry(collectorRegistry, groupingKey);
     }
 }

--- a/platform/metrics/api/src/main/java/org/opennms/horizon/metrics/api/OnmsMetricsAdapter.java
+++ b/platform/metrics/api/src/main/java/org/opennms/horizon/metrics/api/OnmsMetricsAdapter.java
@@ -29,8 +29,9 @@
 package org.opennms.horizon.metrics.api;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
 
-import java.io.IOException;
+import java.util.Map;
 
 
 public interface OnmsMetricsAdapter {
@@ -38,8 +39,9 @@ public interface OnmsMetricsAdapter {
     /**
      * Push metrics to the adapter
      *
-     * @param collector - collector, a metric
+     * @param registry - collector registry with a set of metrics
+     * @param groupingKey - Map of grouping keys ( labels, values)
      */
-    void push(Collector collector);
+    void pushRegistry(CollectorRegistry registry, Map<String, String> groupingKey);
 
 }

--- a/platform/metrics/impl/src/main/java/org/opennms/horizon/metrics/impl/PrometheusPushGatewayAdapter.java
+++ b/platform/metrics/impl/src/main/java/org/opennms/horizon/metrics/impl/PrometheusPushGatewayAdapter.java
@@ -29,12 +29,14 @@
 package org.opennms.horizon.metrics.impl;
 
 import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
 import org.opennms.horizon.metrics.api.OnmsMetricsAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class PrometheusPushGatewayAdapter implements OnmsMetricsAdapter {
 
@@ -48,12 +50,11 @@ public class PrometheusPushGatewayAdapter implements OnmsMetricsAdapter {
 
 
     @Override
-    public void push(Collector collector) {
-
+    public void pushRegistry(CollectorRegistry registry, Map<String, String> groupingKey) {
         try {
-            pushGateway.pushAdd(collector, DEFAULT_JOB_PUSHGATEWAY);
+            pushGateway.pushAdd(registry, DEFAULT_JOB_PUSHGATEWAY);
         } catch (IOException e) {
-            LOG.error("Exception while pushing metrics for metrics : {}", collector, e);
+            LOG.error("Exception while pushing metrics for : {}", registry, e);
         }
     }
 }


### PR DESCRIPTION
Register metrics once and push registry to push gateway
Fix graphql query to make a query without labels

## Description
<!-- Prometheus push gateway should avoid overriding metrics with same name by using grouping key -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-303

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
