### PR TITLE
Rename MinionHeader to Identity, introduce new structs.

### DIFF
--- a/minion-gateway/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
+++ b/minion-gateway/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
@@ -3,7 +3,7 @@ package org.opennms.miniongateway.grpc.server;
 import com.codahale.metrics.MetricRegistry;
 import io.grpc.stub.StreamObserver;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
-import org.opennms.cloud.grpc.minion.MinionHeader;
+import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
 import org.opennms.core.grpc.common.GrpcIpcServer;
@@ -89,7 +89,7 @@ public class GrpcServerConfig {
         @Autowired LocationIndependentRpcClientFactory locationIndependentRpcClientFactory,
         @Autowired MinionRpcStreamConnectionManager minionRpcStreamConnectionManager,
         @Autowired @Qualifier("minionToCloudRPCProcessor") BiConsumer<RpcRequestProto, StreamObserver<RpcResponseProto>> minionToCloudRPCProcessor,
-        @Autowired @Qualifier("cloudToMinionMessageProcessor") BiConsumer<MinionHeader, StreamObserver<CloudToMinionMessage>> cloudToMinionMessageProcessor
+        @Autowired @Qualifier("cloudToMinionMessageProcessor") BiConsumer<Identity, StreamObserver<CloudToMinionMessage>> cloudToMinionMessageProcessor
     ) throws Exception {
 
         OpennmsGrpcServer server = new OpennmsGrpcServer(serverBuilder, Arrays.asList(

--- a/minion-gateway/src/main/java/org/opennms/miniongateway/grpc/server/stub/StubCloudToMinionMessageProcessor.java
+++ b/minion-gateway/src/main/java/org/opennms/miniongateway/grpc/server/stub/StubCloudToMinionMessageProcessor.java
@@ -2,19 +2,19 @@ package org.opennms.miniongateway.grpc.server.stub;
 
 import io.grpc.stub.StreamObserver;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
-import org.opennms.cloud.grpc.minion.MinionHeader;
+import org.opennms.cloud.grpc.minion.Identity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.BiConsumer;
 
-public class StubCloudToMinionMessageProcessor implements BiConsumer<MinionHeader, StreamObserver<CloudToMinionMessage>> {
+public class StubCloudToMinionMessageProcessor implements BiConsumer<Identity, StreamObserver<CloudToMinionMessage>> {
     private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(StubCloudToMinionMessageProcessor.class);
 
     private Logger log = DEFAULT_LOGGER;
 
     @Override
-    public void accept(MinionHeader minionHeader, StreamObserver<CloudToMinionMessage> cloudToMinionMessageStreamObserver) {
+    public void accept(Identity minionHeader, StreamObserver<CloudToMinionMessage> cloudToMinionMessageStreamObserver) {
         log.info("Have Message to send to Minion: system-id={}, location={}",
             minionHeader.getSystemId(),
             minionHeader.getLocation());

--- a/shared-lib/ipc/grpc/client/src/main/java/org/opennms/poc/ignite/grpc/client/internal/StubGrpcClient.java
+++ b/shared-lib/ipc/grpc/client/src/main/java/org/opennms/poc/ignite/grpc/client/internal/StubGrpcClient.java
@@ -18,7 +18,7 @@ import java.util.function.Predicate;
 import org.opennms.cloud.grpc.minion.CloudServiceGrpc.CloudServiceBlockingStub;
 import org.opennms.cloud.grpc.minion.CloudServiceGrpc.CloudServiceStub;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
-import org.opennms.cloud.grpc.minion.MinionHeader;
+import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.cloud.grpc.minion.MinionToCloudMessage;
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
@@ -114,7 +114,7 @@ public class StubGrpcClient implements GrpcClient {
   }
 
   public Session streamFromCloud(Consumer<CloudToMinionMessage> consumer) {
-    MinionHeader header = MinionHeader.newBuilder()
+    Identity header = Identity.newBuilder()
       .setLocation(minionLocation)
       .setSystemId(minionServerId)
       .build();

--- a/shared-lib/ipc/grpc/contract/src/main/proto/opennms/rpc/echo/echo.proto
+++ b/shared-lib/ipc/grpc/contract/src/main/proto/opennms/rpc/echo/echo.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+package opennms.rpc.echo;
+
+option java_multiple_files = true;
+option java_package = "org.opennms.cloud.grpc.minion.rpc.echo";
+
+import "opennms_minion_ipc.proto";
+
+message EchoRequest {
+  minion.Identity identity = 1;
+  uint64 id = 2;
+  string message = 3;
+  optional string body = 4;
+  int64 delay = 5;
+  bool throw = 6;
+}
+
+message EchoResponse {
+  // to be moved to envelope
+  minion.Identity identity = 1;
+  int64 id = 2;
+  string error =3 ;
+  string message = 4;
+  optional string body = 5;
+}

--- a/shared-lib/ipc/grpc/contract/src/main/proto/opennms/sink/heatbeat/heartbeat.proto
+++ b/shared-lib/ipc/grpc/contract/src/main/proto/opennms/sink/heatbeat/heartbeat.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package opennms.sink.heartbeat;
+
+option java_multiple_files = true;
+option java_package = "org.opennms.cloud.grpc.minion.sink.heartbeat";
+
+import "google/protobuf/timestamp.proto";
+import "opennms_minion_ipc.proto";
+
+message HeartbeatMessage {
+  minion.Identity identity = 1;
+  google.protobuf.Timestamp timestamp = 2;
+}

--- a/shared-lib/ipc/grpc/contract/src/main/proto/opennms_minion_ipc.proto
+++ b/shared-lib/ipc/grpc/contract/src/main/proto/opennms_minion_ipc.proto
@@ -46,11 +46,10 @@ service CloudService {
   // > ad hoc calls echo/heartbeat ?
   // OpenNMSIpc.RpcStreaming
   rpc CloudToMinionRPC (stream RpcResponseProto) returns (stream RpcRequestProto) {}
-//  rpc CloudToMinionRPC2 (stream RpcMinionStreamMessage) returns (stream RpcCloudStreamMessage) {}
   // Messages sent from Cloud to Minion (i.e. Twin Updates), called SinkStreaming in Horizon
   // 3. > incremental update of workflow v56 (delta of changes)
   // Twin.SinkStreaming
-  rpc CloudToMinionMessages (MinionHeader) returns (stream CloudToMinionMessage) {}
+  rpc CloudToMinionMessages (Identity) returns (stream CloudToMinionMessage) {}
 
   // RPCs triggered from Minion to Cloud (i.e. Twin Registration Request)
   // 1. < I am interested in twin objects of workflow
@@ -63,8 +62,7 @@ service CloudService {
   rpc MinionToCloudMessages (stream MinionToCloudMessage) returns (google.protobuf.Empty) {}
 }
 
-
-message MinionHeader {
+message Identity {
   string system_id = 1;
   string location = 2;
 }

--- a/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/OpennmsGrpcServer.java
+++ b/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/OpennmsGrpcServer.java
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
-import org.opennms.cloud.grpc.minion.MinionHeader;
+import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.cloud.grpc.minion.MinionToCloudMessage;
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
@@ -124,7 +124,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     // Maintains the map of sink consumer executor and by module Id.
     private final Map<String, ExecutorService> sinkConsumersByModuleId = new ConcurrentHashMap<>();
     private BiConsumer<RpcRequestProto, StreamObserver<RpcResponseProto>> incomingRpcHandler;
-    private BiConsumer<MinionHeader, StreamObserver<CloudToMinionMessage>> outgoingMessageHandler;
+    private BiConsumer<Identity, StreamObserver<CloudToMinionMessage>> outgoingMessageHandler;
 
 //========================================
 // Constructor
@@ -333,7 +333,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
         this.incomingRpcHandler = handler;
     }
 
-    public void setOutgoingMessageHandler(BiConsumer<MinionHeader, StreamObserver<CloudToMinionMessage>> outgoingMessageHandler) {
+    public void setOutgoingMessageHandler(BiConsumer<Identity, StreamObserver<CloudToMinionMessage>> outgoingMessageHandler) {
         this.outgoingMessageHandler = outgoingMessageHandler;
     }
 

--- a/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/manager/adapter/CloudServiceDelegate.java
+++ b/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/manager/adapter/CloudServiceDelegate.java
@@ -3,7 +3,7 @@ package org.opennms.core.ipc.grpc.server.manager.adapter;
 import com.google.protobuf.Empty;
 import io.grpc.stub.StreamObserver;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
-import org.opennms.cloud.grpc.minion.MinionHeader;
+import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.cloud.grpc.minion.MinionToCloudMessage;
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
@@ -12,7 +12,7 @@ public interface CloudServiceDelegate {
 
   StreamObserver<RpcResponseProto> cloudToMinionRPC(StreamObserver<RpcRequestProto> responseObserver);
 
-  void cloudToMinionMessages(MinionHeader request, StreamObserver<CloudToMinionMessage> responseObserver);
+  void cloudToMinionMessages(Identity request, StreamObserver<CloudToMinionMessage> responseObserver);
 
   void minionToCloudRPC(RpcRequestProto request, StreamObserver<RpcResponseProto> responseObserver);
 

--- a/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/manager/adapter/DelegateAdapter.java
+++ b/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/manager/adapter/DelegateAdapter.java
@@ -4,7 +4,7 @@ import com.google.protobuf.Empty;
 import io.grpc.stub.StreamObserver;
 import org.opennms.cloud.grpc.minion.CloudServiceGrpc.CloudServiceImplBase;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
-import org.opennms.cloud.grpc.minion.MinionHeader;
+import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.cloud.grpc.minion.MinionToCloudMessage;
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
@@ -23,7 +23,7 @@ public class DelegateAdapter extends CloudServiceImplBase {
     }
 
     @Override
-    public void cloudToMinionMessages(MinionHeader request, StreamObserver<CloudToMinionMessage> responseObserver) {
+    public void cloudToMinionMessages(Identity request, StreamObserver<CloudToMinionMessage> responseObserver) {
         delegate.cloudToMinionMessages(request, responseObserver);
     }
 

--- a/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/manager/adapter/MinionRSTransportAdapter.java
+++ b/shared-lib/ipc/grpc/server/src/main/java/org/opennms/core/ipc/grpc/server/manager/adapter/MinionRSTransportAdapter.java
@@ -6,7 +6,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import org.opennms.cloud.grpc.minion.CloudServiceGrpc.CloudServiceImplBase;
 import org.opennms.cloud.grpc.minion.CloudToMinionMessage;
-import org.opennms.cloud.grpc.minion.MinionHeader;
+import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.cloud.grpc.minion.MinionToCloudMessage;
 import org.opennms.cloud.grpc.minion.RpcRequestProto;
 import org.opennms.cloud.grpc.minion.RpcResponseProto;
@@ -14,12 +14,12 @@ import org.opennms.cloud.grpc.minion.RpcResponseProto;
 public class MinionRSTransportAdapter extends CloudServiceImplBase {
 
     private final Function<StreamObserver<RpcRequestProto>, StreamObserver<RpcResponseProto>> cloudToMinionRPC;
-    private final BiConsumer<MinionHeader, StreamObserver<CloudToMinionMessage>> cloudToMinionMessages;
+    private final BiConsumer<Identity, StreamObserver<CloudToMinionMessage>> cloudToMinionMessages;
     private final BiConsumer<RpcRequestProto, StreamObserver<RpcResponseProto>> minionToCloudRPC;
     private final Function<StreamObserver<Empty>, StreamObserver<MinionToCloudMessage>> minionToCloudMessages;
 
     public MinionRSTransportAdapter(Function<StreamObserver<RpcRequestProto>, StreamObserver<RpcResponseProto>> cloudToMinionRPC,
-        BiConsumer<MinionHeader, StreamObserver<CloudToMinionMessage>> cloudToMinionMessages,
+        BiConsumer<Identity, StreamObserver<CloudToMinionMessage>> cloudToMinionMessages,
         BiConsumer<RpcRequestProto, StreamObserver<RpcResponseProto>> minionToCloudRPC,
         Function<StreamObserver<Empty>, StreamObserver<MinionToCloudMessage>> minionToCloudMessages) {
         this.cloudToMinionRPC = cloudToMinionRPC;
@@ -34,7 +34,7 @@ public class MinionRSTransportAdapter extends CloudServiceImplBase {
     }
 
     @Override
-    public void cloudToMinionMessages(MinionHeader request, StreamObserver<CloudToMinionMessage> responseObserver) {
+    public void cloudToMinionMessages(Identity request, StreamObserver<CloudToMinionMessage> responseObserver) {
         cloudToMinionMessages.accept(request, responseObserver);
     }
 


### PR DESCRIPTION
A basic update bringing proto structures for further work. Rename of `MinionHeader` into `Identity` as it can be later used in rpc envelopes.