### PR TITLE
HS-279: Use undefined val for generated MaybeInput type

### DIFF
--- a/ui/codegen.yml
+++ b/ui/codegen.yml
@@ -9,4 +9,5 @@ generates:
       - "typed-document-node"
     config: 
       dedupeFragments: true
+      maybeValue: T
 

--- a/ui/src/components/Appliances/AddDeviceCtrl.vue
+++ b/ui/src/components/Appliances/AddDeviceCtrl.vue
@@ -101,31 +101,32 @@ import { useDeviceMutations } from '@/store/Mutations/deviceMutations'
 import { useApplianceQueries } from '@/store/Queries/applianceQueries'
 import useModal from '@/composables/useModal'
 import useSnackbar from '@/composables/useSnackbar'
+import { DeviceCreateDtoInput } from '@/types/graphql'
 
 const { showSnackbar } = useSnackbar()
 const { openModal, closeModal, isVisible } = useModal()
 const deviceMutations = useDeviceMutations()
 const applianceQueries = useApplianceQueries()
 
-const defaultDevice = { 
-  label: '',
-  location: '',
+const defaultDevice: DeviceCreateDtoInput = { 
+  label: undefined,
+  location: undefined,
   latitude: undefined,
   longitude: undefined,
-  monitoringArea: '',
-  managementIp: '',
+  monitoringArea: undefined,
+  managementIp: undefined,
   port: undefined,
-  snmpCommunityString: ''
+  snmpCommunityString: undefined
 }
 
 const device = reactive({ ...defaultDevice })
 
 const save = async () => {
-  // convert the field value to null if their value is an empty string (entered then erased the input field returns an empty string) - empty string as value in payload causes error when adding device.
+  // convert the field value to undefined if their value is an empty string (entered then erased the input field returns an empty string) - empty string as value in payload causes error when adding device.
   Object.assign(device, {
-    port: device.port || null,
-    latitude: device.latitude || null,
-    longitude: device.longitude || null
+    port: device.port || undefined,
+    latitude: device.latitude || undefined,
+    longitude: device.longitude || undefined
   })
 
   await deviceMutations.addDevice({ device })

--- a/ui/src/types/graphql.ts
+++ b/ui/src/types/graphql.ts
@@ -1,6 +1,6 @@
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
+export type Maybe<T> = T;
+export type InputMaybe<T> = T;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
@@ -366,7 +366,7 @@ export type TimeSeriesQueryResult = {
 export type AlarmsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AlarmsQuery = { __typename?: 'Query', listAlarms?: { __typename?: 'AlarmCollectionDTO', alarms?: Array<{ __typename?: 'AlarmDTO', id?: number | null, description?: string | null, severity?: string | null, lastEventTime?: any | null } | null> | null } | null };
+export type AlarmsQuery = { __typename?: 'Query', listAlarms?: { __typename?: 'AlarmCollectionDTO', alarms?: Array<{ __typename?: 'AlarmDTO', id?: number, description?: string, severity?: string, lastEventTime?: any }> } };
 
 export type ClearAlarmMutationVariables = Exact<{
   id: Scalars['Long'];
@@ -374,51 +374,51 @@ export type ClearAlarmMutationVariables = Exact<{
 }>;
 
 
-export type ClearAlarmMutation = { __typename?: 'Mutation', clearAlarm?: string | null };
+export type ClearAlarmMutation = { __typename?: 'Mutation', clearAlarm?: string };
 
 export type AddDeviceMutationVariables = Exact<{
   device: DeviceCreateDtoInput;
 }>;
 
 
-export type AddDeviceMutation = { __typename?: 'Mutation', addDevice?: number | null };
+export type AddDeviceMutation = { __typename?: 'Mutation', addDevice?: number };
 
 export type CreateEventMutationVariables = Exact<{
   event: EventDtoInput;
 }>;
 
 
-export type CreateEventMutation = { __typename?: 'Mutation', createEvent?: boolean | null };
+export type CreateEventMutation = { __typename?: 'Mutation', createEvent?: boolean };
 
-export type DeviceTablePartsFragment = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number | null, label?: string | null, createTime?: any | null } | null> | null } | null };
+export type DeviceTablePartsFragment = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number, label?: string, createTime?: any }> } };
 
-export type MinionTablePartsFragment = { __typename?: 'Query', listMinions?: { __typename?: 'MinionCollectionDTO', minions?: Array<{ __typename?: 'MinionDTO', id?: string | null, label?: string | null, status?: string | null, location?: string | null, lastUpdated?: any | null } | null> | null } | null };
+export type MinionTablePartsFragment = { __typename?: 'Query', listMinions?: { __typename?: 'MinionCollectionDTO', minions?: Array<{ __typename?: 'MinionDTO', id?: string, label?: string, status?: string, location?: string, lastUpdated?: any }> } };
 
-export type MetricPartsFragment = { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any | null, value?: Array<number | null> | null } | null> | null } | null };
+export type MetricPartsFragment = { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number> }> } };
 
-export type MinionUptimePartsFragment = { __typename?: 'Query', minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any | null, value?: Array<number | null> | null } | null> | null } | null } | null };
+export type MinionUptimePartsFragment = { __typename?: 'Query', minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number> }> } } };
 
-export type MinionLatencyPartsFragment = { __typename?: 'Query', minionLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any | null, value?: Array<number | null> | null } | null> | null } | null } | null };
+export type MinionLatencyPartsFragment = { __typename?: 'Query', minionLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number> }> } } };
 
 export type ListDevicesForTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ListDevicesForTableQuery = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number | null, label?: string | null, createTime?: any | null } | null> | null } | null };
+export type ListDevicesForTableQuery = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number, label?: string, createTime?: any }> } };
 
 export type ListMinionsForTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ListMinionsForTableQuery = { __typename?: 'Query', listMinions?: { __typename?: 'MinionCollectionDTO', minions?: Array<{ __typename?: 'MinionDTO', id?: string | null, label?: string | null, status?: string | null, location?: string | null, lastUpdated?: any | null } | null> | null } | null, minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any | null, value?: Array<number | null> | null } | null> | null } | null } | null, minionLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any | null, value?: Array<number | null> | null } | null> | null } | null } | null };
+export type ListMinionsForTableQuery = { __typename?: 'Query', listMinions?: { __typename?: 'MinionCollectionDTO', minions?: Array<{ __typename?: 'MinionDTO', id?: string, label?: string, status?: string, location?: string, lastUpdated?: any }> }, minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number> }> } }, minionLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number> }> } } };
 
 export type ListMinionsAndDevicesForTablesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ListMinionsAndDevicesForTablesQuery = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number | null, label?: string | null, createTime?: any | null } | null> | null } | null, listMinions?: { __typename?: 'MinionCollectionDTO', minions?: Array<{ __typename?: 'MinionDTO', id?: string | null, label?: string | null, status?: string | null, location?: string | null, lastUpdated?: any | null } | null> | null } | null, minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any | null, value?: Array<number | null> | null } | null> | null } | null } | null, minionLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any | null, value?: Array<number | null> | null } | null> | null } | null } | null };
+export type ListMinionsAndDevicesForTablesQuery = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number, label?: string, createTime?: any }> }, listMinions?: { __typename?: 'MinionCollectionDTO', minions?: Array<{ __typename?: 'MinionDTO', id?: string, label?: string, status?: string, location?: string, lastUpdated?: any }> }, minionUptime?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number> }> } }, minionLatency?: { __typename?: 'TimeSeriesQueryResult', data?: { __typename?: 'TSData', result?: Array<{ __typename?: 'TSResult', metric?: any, value?: Array<number> }> } } };
 
 export type ListDevicesForGeomapQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ListDevicesForGeomapQuery = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number | null, label?: string | null, foreignSource?: string | null, foreignId?: string | null, labelSource?: string | null, sysOid?: string | null, sysName?: string | null, sysDescription?: string | null, sysContact?: string | null, sysLocation?: string | null, location?: { __typename?: 'LocationDTO', latitude?: number | null, longitude?: number | null } | null } | null> | null } | null };
+export type ListDevicesForGeomapQuery = { __typename?: 'Query', listDevices?: { __typename?: 'DeviceCollectionDTO', devices?: Array<{ __typename?: 'DeviceDTO', id?: number, label?: string, foreignSource?: string, foreignId?: string, labelSource?: string, sysOid?: string, sysName?: string, sysDescription?: string, sysContact?: string, sysLocation?: string, location?: { __typename?: 'LocationDTO', latitude?: number, longitude?: number } }> } };
 
 export const DeviceTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"DeviceTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listDevices"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"devices"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"createTime"}}]}}]}}]}}]} as unknown as DocumentNode<DeviceTablePartsFragment, unknown>;
 export const MinionTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MinionTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listMinions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"minions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"lastUpdated"}}]}}]}}]}}]} as unknown as DocumentNode<MinionTablePartsFragment, unknown>;


### PR DESCRIPTION
## Description
Changed the generated types to use `undefined` for potential missing values, instead of null.
This is done because feather input models work with undefined.

## Jira link(s)
- https://issues.opennms.org/browse/HS-279

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.
