### PR TITLE
HS-312: Update skaffold vars

### DIFF
--- a/keycloak-ui/Dockerfile
+++ b/keycloak-ui/Dockerfile
@@ -1,5 +1,5 @@
 # After testing, version 18 and 17.0.1 works on M1 MacBook, for more information https://github.com/keycloak/keycloak/issues/8825
-FROM quay.io/keycloak/keycloak:18.0.0
+FROM quay.io/keycloak/keycloak:19.0.1
 
 USER 0
 

--- a/keycloak-ui/Dockerfile
+++ b/keycloak-ui/Dockerfile
@@ -1,5 +1,5 @@
 # After testing, version 18 and 17.0.1 works on M1 MacBook, for more information https://github.com/keycloak/keycloak/issues/8825
-FROM quay.io/keycloak/keycloak:19.0.1
+FROM quay.io/keycloak/keycloak:18.0.0
 
 USER 0
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -9,7 +9,7 @@ build:
   - image: opennms/horizon-stream-core
     context: platform
     custom:
-      buildCommand: "mvn install -Pbuild-docker-images-enabled -DskipTests -Ddocker.image=${IMAGE} -Ddocker.skipPush=${!PUSH_IMAGE}"
+      buildCommand: "mvn install -Pbuild-docker-images-enabled -DskipTests -Ddocker.image=$IMAGE -Ddocker.skipPush=!$PUSH_IMAGE"
       dependencies:
         paths: ["."]
         ignore: [


### PR DESCRIPTION
## Description
Updates this part of the build cmd: `Ddocker.image=$IMAGE -Ddocker.skipPush=!$PUSH_IMAGE`
Changes keycloak-ui version to 18.0.0


## Jira link(s)
- https://issues.opennms.org/browse/HS-312

## Flagged for review
Probably should be tested on mac, to be safe

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
