### PR TITLE
HS-305: Add leaflet dark mode tiles, useTheme hook

### DIFF
--- a/ui/src/components/Layout/Menubar.vue
+++ b/ui/src/components/Layout/Menubar.vue
@@ -31,18 +31,11 @@ import LightDarkMode from '@featherds/icon/action/LightDarkMode'
 import LogOut from '@featherds/icon/action/LogOut'
 import Logo from '@/assets/Logo.vue'
 import useKeycloak from '@/composables/useKeycloak'
+import useTheme from '@/composables/useTheme'
 import { logout } from '@/services/authService'
 
 const { keycloak } = useKeycloak()
-
-const isDark = useDark({
-  selector: 'body',
-  attribute: 'class',
-  valueDark: 'open-dark',
-  valueLight: 'open-light'
-})
-
-const toggleDark = useToggle(isDark)
+const { toggleDark } = useTheme()
 </script>
 
 <style lang="scss">

--- a/ui/src/components/Layout/Menubar.vue
+++ b/ui/src/components/Layout/Menubar.vue
@@ -15,6 +15,7 @@
         :icon="LightDarkMode"
         class="pointer menu-icon"
         @click="toggleDark()"
+        data-test="toggle-dark"
       />
 
       <FeatherIcon

--- a/ui/src/composables/useTheme.ts
+++ b/ui/src/composables/useTheme.ts
@@ -1,0 +1,24 @@
+const isDark = useDark({
+  selector: 'body',
+  attribute: 'class',
+  valueDark: 'open-dark',
+  valueLight: 'open-light'
+})
+
+const toggleDark= useToggle(isDark)
+
+const useTheme = () => {
+  let onThemeChangeCallback: () => void
+
+  const onThemeChange = (callback: () => void) => onThemeChangeCallback = callback
+
+  watch(isDark, () => {
+    if (onThemeChangeCallback) {
+      onThemeChangeCallback()
+    }
+  })
+
+  return { isDark, toggleDark, onThemeChange }
+}
+
+export default useTheme

--- a/ui/src/composables/useTheme.ts
+++ b/ui/src/composables/useTheme.ts
@@ -5,7 +5,7 @@ const isDark = useDark({
   valueLight: 'open-light'
 })
 
-const toggleDark= useToggle(isDark)
+const toggleDark = useToggle(isDark)
 
 const useTheme = () => {
   let onThemeChangeCallback: () => void

--- a/ui/tests/Appliances/appliances.test.ts
+++ b/ui/tests/Appliances/appliances.test.ts
@@ -7,11 +7,9 @@ import useKeycloak from '@/composables/useKeycloak'
 import { KeycloakInstance } from '@dsb-norge/vue-keycloak-js/dist/types'
 import setupWrapper from 'tests/setupWrapper'
 
-
 const wrapper = setupWrapper({
   component: Appliances
 })
-
 
 it('should have a header',  async () => {
   const { setKeycloak } = useKeycloak()

--- a/ui/tests/Layout/menubar.test.ts
+++ b/ui/tests/Layout/menubar.test.ts
@@ -1,4 +1,7 @@
 import Menubar from '@/components/Layout/Menubar.vue'
+import useKeycloak from '@/composables/useKeycloak'
+import useTheme from '@/composables/useTheme'
+import { KeycloakInstance } from '@dsb-norge/vue-keycloak-js/dist/types'
 import { createTestingPinia } from '@pinia/testing'
 import { mount } from '@vue/test-utils'
 
@@ -6,3 +9,25 @@ test('The menubar mounts', () => {
   const wrapper = mount(Menubar, { global: { plugins: [createTestingPinia()] }, props: {} })
   expect(wrapper).toBeTruthy()
 })
+
+test('The toggle dark btn triggers the composible function, and the ref updates', async () => {
+  // mock authenticate to show dark/light mode btn
+  const { setKeycloak } = useKeycloak()
+  setKeycloak({ authenticated: true } as KeycloakInstance)
+
+  // get theme hook, mock on change theme callback
+  const theme = useTheme()
+  const unchangedThemeValue = theme.isDark.value
+  const mockFn = vi.fn(() => 'this is a mock callback')
+  theme.onThemeChange(mockFn)
+  
+  // get and trigger dark/light mode btn
+  const wrapper = mount(Menubar, { global: { plugins: [createTestingPinia()] }, props: {} })
+  const toggleDarkBtn = wrapper.get('[data-test="toggle-dark"]')
+  await toggleDarkBtn.trigger('click')
+
+  // expect theme callback to have run and isDark value to have changes
+  expect(mockFn).toHaveBeenCalledOnce()
+  expect(theme.isDark.value).toBe(!unchangedThemeValue)
+})
+


### PR DESCRIPTION
## Description
Moves the useDark functionality into a useTheme composable. 
Adds separate leaflet tile layer for dark mode.

## Jira link(s)
- https://issues.opennms.org/browse/HS-305

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [x] Documentation has been updated as necessary.

![screenshot-127 0 0 1_3001-2022 08 22-14_33_44](https://user-images.githubusercontent.com/8680122/185994610-5aebd862-495a-43bb-a293-1b83e987f05e.png)
![screenshot-127 0 0 1_3001-2022 08 22-14_34_10](https://user-images.githubusercontent.com/8680122/185994625-9d02efe3-9d99-4b9a-bda0-e56eb743b185.png)

