### PR TITLE
Handling of application level reconnection.

### DIFF
--- a/minion/assembly/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/minion/assembly/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -26,7 +26,7 @@ color.debug = cyan
 color.trace = cyan
 
 # Common pattern layout for appenders
-log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %-32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %encode{%.-500m}{CRLF}%n
+log4j2.pattern = %d{ISO8601} | %-5p | %-16t | %c | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %encode{%.-500m}{CRLF}%n
 log4j2.out.pattern = \u001b[90m%d{HH:mm:ss\.SSS}\u001b[0m %highlight{%-5level}{FATAL=${color.fatal}, ERROR=${color.error}, WARN=${color.warn}, INFO=${color.info}, DEBUG=${color.debug}, TRACE=${color.trace}} \u001b[90m[%t]\u001b[0m %msg%n%throwable
 
 

--- a/minion/minion-ipc/twin-core/pom.xml
+++ b/minion/minion-ipc/twin-core/pom.xml
@@ -22,7 +22,7 @@
         </dependency>
         <dependency>
             <groupId>org.opennms.horizon.shared</groupId>
-            <artifactId>ipc-grpc-contract</artifactId>
+            <artifactId>ipc-grpc-client</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-client/src/main/java/org/opennms/core/ipc/grpc/client/ReconnectStrategy.java
+++ b/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-client/src/main/java/org/opennms/core/ipc/grpc/client/ReconnectStrategy.java
@@ -1,0 +1,7 @@
+package org.opennms.core.ipc.grpc.client;
+
+public interface ReconnectStrategy {
+
+    void activate();
+
+}

--- a/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-client/src/main/java/org/opennms/core/ipc/grpc/client/SimpleReconnectStrategy.java
+++ b/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-client/src/main/java/org/opennms/core/ipc/grpc/client/SimpleReconnectStrategy.java
@@ -1,0 +1,43 @@
+package org.opennms.core.ipc.grpc.client;
+
+import io.grpc.ConnectivityState;
+import io.grpc.ManagedChannel;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class SimpleReconnectStrategy implements Runnable, ReconnectStrategy {
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ManagedChannel channel;
+    private final Runnable onConnect;
+    private final Runnable onDisconnect;
+    private ScheduledFuture<?> reconnectTask;
+
+    public SimpleReconnectStrategy(ManagedChannel channel, Runnable onConnect, Runnable onDisconnect) {
+        this.channel = channel;
+        this.onConnect = onConnect;
+        this.onDisconnect = onDisconnect;
+    }
+
+    @Override
+    public void activate() {
+        onDisconnect.run();
+        reconnectTask = executor.scheduleAtFixedRate(this, 5000, 5000, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void run() {
+        ConnectivityState state = channel.getState(true);
+        if (state == ConnectivityState.READY) {
+            if (reconnectTask != null) {
+                reconnectTask.cancel(false);
+                onConnect.run();
+                reconnectTask = null;
+            }
+        } else {
+            reconnectTask = executor.scheduleAtFixedRate(this, 5000, 5000, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-client/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -35,7 +35,7 @@
     <bean id="metricRegistry" class="com.codahale.metrics.MetricRegistry"/>
     <bean id="tracer" class="io.opentracing.noop.NoopTracerFactory" factory-method="create"/>
 
-    <bean id="minionClient" class="org.opennms.core.ipc.grpc.client.MinionGrpcClient" init-method="start" destroy-method="close">
+    <bean id="minionClient" class="org.opennms.core.ipc.grpc.client.MinionGrpcClient" init-method="start" destroy-method="shutdown">
         <argument ref="ipcIdentity"/>
         <argument ref="configAdmin"/>
         <argument ref="metricRegistry"/>


### PR DESCRIPTION
When GRPC channel leaves off the READY state, the stream observers become invalid.
While they do not throw any exception, it is not possible to receive nor publish any update using them.
GRPC api for java does not provide a way to track transition between managed channel states, it allows only to notify about state change.
Yet state change change is not being made unless there is an rpc operation requested.
Its kind of chicken-egg problem as GRPC client code we do, do not attempt to perform operations (where it is aware of channel state) unless channel is ready.
In order to gain a control over channel we need to force a state check. By this we can catch disconnect and connect time.
This commit introduces 30s window to monitor connection state.
In event of communication failure a reconnection attempt shall be made within this window.
Note that some operations (ie. rpc responses) will simply fail as there is no retry logic for them.
