### PR TITLE
Working snmp monitor and adjustments to snmp strategy lookup.

### DIFF
--- a/minion/minion-features/src/main/resources/features.xml
+++ b/minion/minion-features/src/main/resources/features.xml
@@ -9,10 +9,13 @@
     <repository>mvn:org.opennms.horizon.minion/observability-features/${project.version}/xml/features</repository>
     <repository>mvn:org.opennms.horizon.minion/plugin-features/${project.version}/xml/features</repository>
     <repository>mvn:org.opennms.horizon.minion/icmp-plugin/${project.version}/xml/features</repository>
+    <repository>mvn:org.opennms.horizon.shared/snmp-api/${project.version}/xml/features</repository>
+    <repository>mvn:org.opennms.horizon.minion/snmp-plugin/${project.version}/xml/features</repository>
 
     <feature name="minion-ng">
         <feature>taskset-minion</feature>
         <feature>icmp-plugins</feature>
+        <feature>snmp-plugins</feature>
     </feature>
 
 </features>

--- a/minion/plugins/snmp-plugin/src/main/feature/feature.xml
+++ b/minion/plugins/snmp-plugin/src/main/feature/feature.xml
@@ -9,6 +9,15 @@
         <feature version="${project.version}">snmp-api</feature>
     </feature>
 
+    <feature name="snmp-snmp4" version="${project.version}" description="Horizon :: SNMP4j">
+        <feature prerequisite="true">wrap</feature>
+        <feature version="${project.version}">snmp-api</feature>
+        <bundle>wrap:mvn:org.snmp4j/snmp4j/${snmp4j.version}</bundle>
+        <bundle>mvn:commons-lang/commons-lang/${commons.lang.version}</bundle>
+        <bundle>mvn:org.opennms.horizon.shared/horizon-common-logging/${project.version}</bundle>
+        <bundle>mvn:org.opennms.horizon.minion/snmp4j/${project.version}</bundle>
+    </feature>
+
     <feature name="snmp-plugins" description="OpenNMS SNMP Plugins" version="${project.version}">
         <feature version="${project.version}">plugins-api</feature>
         <feature version="${project.version}">snmp-minion</feature>

--- a/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/UtilInitializer.java
+++ b/minion/plugins/snmp-plugin/src/main/java/org/opennms/horizon/minion/snmp/UtilInitializer.java
@@ -1,0 +1,12 @@
+package org.opennms.horizon.minion.snmp;
+
+import org.opennms.horizon.shared.snmp.SnmpUtils;
+import org.opennms.horizon.shared.snmp.StrategyResolver;
+
+public class UtilInitializer {
+
+    public UtilInitializer(StrategyResolver strategyResolver) {
+        SnmpUtils.setStrategyResolver(strategyResolver);
+    }
+
+}

--- a/minion/plugins/snmp-plugin/src/main/resources/OSGI-INF/blueprint/snmp-plugins.xml
+++ b/minion/plugins/snmp-plugin/src/main/resources/OSGI-INF/blueprint/snmp-plugins.xml
@@ -12,7 +12,7 @@
 
   <bean id="snmpDetectorManager" class="org.opennms.horizon.minion.snmp.SnmpDetectorManager"/>
 
-  <service ref="snmpDetectorManager" interface="ServiceDetectorManager">
+  <service ref="snmpDetectorManager" interface="org.opennms.horizon.minion.plugin.api.ServiceDetectorManager">
     <service-properties>
       <entry key="detector.name" value="SNMPDetector"/>
     </service-properties>
@@ -20,10 +20,16 @@
 
   <bean id="snmpMonitorManager" class="org.opennms.horizon.minion.snmp.SnmpMonitorManager"/>
 
-  <service ref="snmpMonitorManager" interface="ServiceMonitorManager">
+  <service ref="snmpMonitorManager" interface="org.opennms.horizon.minion.plugin.api.ServiceMonitorManager">
     <service-properties>
       <entry key="monitor.name" value="SNMPMonitor"/>
     </service-properties>
   </service>
+
+  <reference id="strategyResolver" interface="org.opennms.horizon.shared.snmp.StrategyResolver" />
+
+  <bean class="org.opennms.horizon.minion.snmp.UtilInitializer">
+    <argument ref="strategyResolver" />
+  </bean>
 
 </blueprint>

--- a/minion/snmp/snmp4j/pom.xml
+++ b/minion/snmp/snmp4j/pom.xml
@@ -62,4 +62,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Bundle-Activator>org.opennms.horizon.minion.snmp.snmp4j.Snmp4JActivator</Bundle-Activator>
+            <Import-Package>
+                org.snmp4j.smi,
+                *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/shared-lib/snmp-api/src/main/java/org/opennms/horizon/shared/snmp/SnmpUtils.java
+++ b/shared-lib/snmp-api/src/main/java/org/opennms/horizon/shared/snmp/SnmpUtils.java
@@ -191,7 +191,7 @@ public abstract class SnmpUtils {
 
     public static String getStrategyClassName() {
         // Use SNMP4J as the default SNMP strategy
-        return getConfig().getProperty("org.opennms.snmp.strategyClass", "org.opennms.netmgt.snmp.snmp4j.Snmp4JStrategy");
+        return getConfig().getProperty("org.opennms.snmp.strategyClass", "org.opennms.horizon.minion.snmp.snmp4j.Snmp4JStrategy");
     }
 
     public static void registerForTraps(final TrapNotificationListener listener, final InetAddress address, final int snmpTrapPort, final List<SnmpV3User> snmpUsers) throws IOException {

--- a/shared-lib/snmp-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/shared-lib/snmp-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -5,7 +5,9 @@
 >
 
   <bean id="strategyResolver" class="org.opennms.horizon.shared.snmp.internal.ServiceBasedStrategyResolver" factory-method="register" destroy-method="unregister"/>
-    
+
+  <service ref="strategyResolver" interface="org.opennms.horizon.shared.snmp.StrategyResolver" />
+
   <reference-list interface="org.opennms.horizon.shared.snmp.SnmpStrategy" availability="optional">
     <reference-listener bind-method="onBind" unbind-method="onUnbind" ref="strategyResolver" />
   </reference-list>

--- a/tooling/ignite-tool/tools/example-task-set.003.json
+++ b/tooling/ignite-tool/tools/example-task-set.003.json
@@ -1,0 +1,17 @@
+{
+  "taskDefinitionList": [
+    {
+      "description": "Monitor localhost ping",
+      "type": "MONITOR",
+      "pluginName": "SNMPMonitor",
+      "schedule": "5000",
+      "parameters": {
+          "host": "192.168.2.1",
+          "oid": "1.3.6.1.2.1.2.2.1.16.1",
+          "operand": "1",
+          "operator": ">="
+      },
+      "id": "59572742-f853-46ac-872f-2b1f3785b7e5"
+    }
+  ]
+}


### PR DESCRIPTION
Abstraction assumed in snmp api require specific class names, also snmp-api itself require a specific strategy to be present.
Given that we run under OSGi the `Class.forName` calls not working properly especially from api module which defines strategy interface.
This commit also bring minor adjustments in minion snmp4j module to let it work under OSGi.