### PR TITLE
[HS-378] Fix environment variable name after migration to spring-webflux

### DIFF
--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -49,7 +49,7 @@ spec:
               value: "http://{{ .Values.OpenNMS.Core.ServiceName }}:{{ .Values.OpenNMS.Core.HttpPort }}"
             - name: TSDB_URL
               value: "http://{{ .Values.Prometheus.Server.ServiceName }}:{{ .Values.Prometheus.Server.Port }}/api/v1/query"
-            - name: SERVER_SERVLET_CONTEXT_PATH
+            - name: SPRING_WEBFLUX_BASE_PATH
               value: /api
           ports:
             - containerPort: {{ .Values.OpenNMS.API.Port }}


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Migration to webflux changed this variable name, this fixes it.

## Jira link(s)
- https://issues.opennms.org/browse/HS-378

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
