### PR TITLE
HS-337,HS-338: Stats: Create platform module for data choices

### DIFF
--- a/platform/assemblies/core-dynamic-dist/pom.xml
+++ b/platform/assemblies/core-dynamic-dist/pom.xml
@@ -119,6 +119,7 @@
                         <feature>scr</feature>
                         <feature>horizon-alarms</feature>
                         <feature>horizon-icmp</feature>
+                        <feature>horizon-datachoices</feature>
                         <feature>horizon-provision</feature>
                         <feature>horizon-inventory</feature>
                         <feature>horizon-minion-heartbeat</feature>

--- a/platform/assemblies/features/pom.xml
+++ b/platform/assemblies/features/pom.xml
@@ -84,6 +84,7 @@
                                 <feature>horizon-events</feature>
                                 <feature>horizon-grpc</feature>
                                 <feature>horizon-icmp</feature>
+                                <feature>horizon-datachoices</feature>
                                 <feature>horizon-inventory</feature>
                                 <feature>horizon-ipc-api</feature>
                                 <feature>horizon-provision</feature>
@@ -432,6 +433,11 @@
         <dependency>
             <groupId>org.opennms.horizon.config</groupId>
             <artifactId>rest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon</groupId>
+            <artifactId>datachoices</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/platform/assemblies/features/src/main/feature/features.xml
+++ b/platform/assemblies/features/src/main/feature/features.xml
@@ -168,6 +168,13 @@
         <bundle>mvn:org.opennms.core.ipc.twin.grpc/publisher/${project.version}</bundle>
     </feature>
 
+    <feature name="horizon-datachoices" version="${project.version}" description="Horizon :: Data Choices">
+        <feature>horizon-db</feature>
+        <feature>onms-httpclient</feature>
+        <bundle>mvn:org.opennms.horizon.common/common-web/${project.version}</bundle>
+        <bundle start-level="80">mvn:org.opennms.horizon/datachoices/${project.version}</bundle>
+    </feature>
+
     <feature name="horizon-core-monitor" version="${project.version}">
         <feature>horizon-metrics-prometheus</feature>
         <feature>horizon-events-api</feature>

--- a/platform/datachoices/pom.xml
+++ b/platform/datachoices/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms.horizon</groupId>
+        <artifactId>horizon</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>datachoices</artifactId>
+    <name>OpenNMS Horizon :: Data Choices</name>
+    <packaging>bundle</packaging>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.opennms.horizon</groupId>
+                <artifactId>horizon-bom</artifactId>
+                <version>0.1.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.opennms.horizon.db</groupId>
+            <artifactId>dao-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.common</groupId>
+            <artifactId>common-web</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.datachoices.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import javax.ws.rs.InternalServerErrorException;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class UsageStatisticsReportDTO {
+
+    private String systemId;
+
+    private String version;
+
+    public String getSystemId() {
+        return this.systemId;
+    }
+
+    public void setSystemId(String systemId) {
+        this.systemId = systemId;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String toJson() {
+        return toJson(false);
+    }
+
+    public String toJson(boolean prettyPrint) {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectWriter writer = mapper.writer();
+        if (prettyPrint) {
+            writer = mapper.writerWithDefaultPrettyPrinter();
+        }
+        try {
+            return writer.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new InternalServerErrorException("Failed to write usage statistics to json string", e);
+        }
+    }
+}

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/StateManager.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/StateManager.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.datachoices.internal;
+
+import org.opennms.horizon.db.dao.api.DataChoicesDao;
+import org.opennms.horizon.db.dao.api.SessionUtils;
+import org.opennms.horizon.db.model.OnmsDataChoices;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class StateManager {
+    private final List<StateChangeHandler> listeners = new ArrayList<>();
+    private DataChoicesDao dataChoicesDao;
+    private SessionUtils sessionUtils;
+
+    public void setEnabled(boolean enabled) {
+        this.sessionUtils.withTransaction(() -> {
+            OnmsDataChoices dataChoice = this.dataChoicesDao.find();
+            for (StateChangeHandler listener : this.listeners) {
+                listener.onEnabledChanged(enabled);
+            }
+            dataChoice.setEnabled(enabled);
+            this.dataChoicesDao.saveOrUpdate(dataChoice);
+        });
+    }
+
+    public OnmsDataChoices getDataChoices() {
+        return this.sessionUtils
+            .withReadOnlyTransaction(() -> this.dataChoicesDao.find());
+    }
+
+    public void onIsEnabledChanged(StateChangeHandler callback) {
+        this.listeners.add(Objects.requireNonNull(callback));
+    }
+
+    public void setDataChoicesDao(DataChoicesDao dataChoicesDao) {
+        this.dataChoicesDao = dataChoicesDao;
+    }
+
+    public void setSessionUtils(SessionUtils sessionUtils) {
+        this.sessionUtils = sessionUtils;
+    }
+
+    public interface StateChangeHandler {
+        void onEnabledChanged(boolean enabled);
+    }
+}

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.datachoices.internal;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.opennms.core.web.HttpClientWrapper;
+import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
+import org.opennms.horizon.datachoices.internal.StateManager.StateChangeHandler;
+import org.opennms.horizon.db.model.OnmsDataChoices;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class UsageStatisticsReporter implements StateChangeHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(UsageStatisticsReporter.class);
+    private static final String POM_PROPERTIES_FILE_NAME = "properties-from-pom.properties";
+    private static final String DISPLAY_VERSION = "display.version";
+    private static final String USAGE_REPORT = "hs-usage-report";
+
+    private StateManager stateManager;
+
+    private String url;
+
+    private long interval;
+
+    private Timer timer;
+
+    public synchronized void init() {
+        OnmsDataChoices dataChoices = this.stateManager.getDataChoices();
+        if (Boolean.TRUE.equals(dataChoices.getEnabled())) {
+            LOG.info("Scheduling usage statistic reporting");
+            schedule();
+        } else {
+            LOG.info("Usage statistic reporting not enabled");
+        }
+        stateManager.onIsEnabledChanged(this);
+    }
+
+    public synchronized void destroy() {
+        if (timer != null) {
+            LOG.info("Disabling scheduled report.");
+            timer.cancel();
+            timer = null;
+        }
+    }
+
+    @Override
+    public void onEnabledChanged(boolean enabled) {
+        if (enabled && timer == null) {
+            schedule();
+        } else if (!enabled && timer != null) {
+            destroy();
+        }
+    }
+
+    public synchronized void schedule() {
+        LOG.info("Scheduling usage statistics report every {} ms", interval);
+        timer = new Timer();
+        timer.schedule(new DataChoicesTimerTask(), 0, interval);
+    }
+
+    public UsageStatisticsReportDTO generateReport() {
+        OnmsDataChoices dataChoices = this.stateManager.getDataChoices();
+
+        UsageStatisticsReportDTO usageStatsReport = new UsageStatisticsReportDTO();
+        usageStatsReport.setSystemId(dataChoices.getSystemId());
+        usageStatsReport.setVersion(getVersion());
+
+        return usageStatsReport;
+    }
+
+    private String getVersion() {
+        Properties properties = getPomProperties();
+        return properties.getProperty(DISPLAY_VERSION, "");
+    }
+
+    private Properties getPomProperties() {
+        Properties properties = new Properties();
+        try (InputStream inputStream = new FileInputStream(POM_PROPERTIES_FILE_NAME)) {
+            properties.load(inputStream);
+        } catch (IOException e) {
+            LOG.warn("Unable to load from generated pom properties file", e);
+        }
+        return properties;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public void setInterval(long interval) {
+        this.interval = interval;
+    }
+
+    public void setStateManager(StateManager stateManager) {
+        this.stateManager = stateManager;
+    }
+
+    private class DataChoicesTimerTask extends TimerTask {
+
+        @Override
+        public void run() {
+            UsageStatisticsReportDTO usageStatsReport = generateReport();
+            String usageStatsReportJson = usageStatsReport.toJson();
+
+            try (HttpClientWrapper clientWrapper = HttpClientWrapper.create();
+                 CloseableHttpClient client = clientWrapper.getClient()) {
+
+                HttpPost httpRequest = new HttpPost(url + USAGE_REPORT);
+                httpRequest.setEntity(new StringEntity(usageStatsReportJson, ContentType.APPLICATION_JSON));
+
+                LOG.info("Sending usage statistics report to {}: {}", httpRequest.getURI(), usageStatsReportJson);
+                client.execute(httpRequest);
+                LOG.info("Successfully sent usage statistics report.");
+
+            } catch (IOException e) {
+                LOG.error("The usage statistics report was not successfully delivered", e);
+            }
+        }
+    }
+}

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
@@ -62,7 +62,7 @@ public class UsageStatisticsReporter implements StateChangeHandler {
 
     public synchronized void init() {
         OnmsDataChoices dataChoices = this.stateManager.getDataChoices();
-        if (Boolean.TRUE.equals(dataChoices.getEnabled())) {
+        if (dataChoices.getEnabled()) {
             LOG.info("Scheduling usage statistic reporting");
             schedule();
         } else {

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/web/DataChoicesRestService.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/web/DataChoicesRestService.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.datachoices.web;
+
+import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Path("/datachoices")
+public interface DataChoicesRestService {
+
+    @POST
+    void toggleUsageStatistics(@QueryParam("toggle") boolean toggle);
+
+    @GET
+    @Produces(value = {MediaType.APPLICATION_JSON})
+    UsageStatisticsReportDTO getUsageStatistics();
+}

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/web/internal/DataChoiceRestServiceImpl.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/web/internal/DataChoiceRestServiceImpl.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.datachoices.web.internal;
+
+import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
+import org.opennms.horizon.datachoices.internal.StateManager;
+import org.opennms.horizon.datachoices.internal.UsageStatisticsReporter;
+import org.opennms.horizon.datachoices.web.DataChoicesRestService;
+
+public class DataChoiceRestServiceImpl implements DataChoicesRestService {
+    private StateManager stateManager;
+    private UsageStatisticsReporter usageStatisticsReporter;
+
+    @Override
+    public void toggleUsageStatistics(boolean toggle) {
+        this.stateManager.setEnabled(toggle);
+    }
+
+    @Override
+    public UsageStatisticsReportDTO getUsageStatistics() {
+        return usageStatisticsReporter.generateReport();
+    }
+
+    public void setStateManager(StateManager stateManager) {
+        this.stateManager = stateManager;
+    }
+
+    public void setUsageStatisticsReporter(UsageStatisticsReporter usageStatisticsReporter) {
+        this.usageStatisticsReporter = usageStatisticsReporter;
+    }
+}

--- a/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -10,9 +10,8 @@
 
     <cm:property-placeholder persistent-id="org.opennms.horizon.datachoices">
         <cm:default-properties>
-
-            <!-- TODO: Change this once stats.opennms.com has been updated for the /hs-usage-report endpoint -->
-            <cm:property name="url" value="http://192.168.1.90:3542/"/> <!-- IP of Machine for local testing -->
+<!--            Note: to test this with a local version of UsageStatsHandler, use the IP of your machine to connect to it outside the l8s cluster -->
+            <cm:property name="url" value="http://stats.opennms.com/"/>
             <cm:property name="interval" value="86400000"/> <!-- 24 hours -->
         </cm:default-properties>
     </cm:property-placeholder>

--- a/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,46 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
+           xsi:schemaLocation="
+                http://www.osgi.org/xmlns/blueprint/v1.0.0
+                https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+                http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
+                http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd
+">
+
+    <cm:property-placeholder persistent-id="org.opennms.horizon.datachoices">
+        <cm:default-properties>
+
+            <!-- TODO: Change this once stats.opennms.com has been updated for the /hs-usage-report endpoint -->
+            <cm:property name="url" value="http://192.168.1.90:3542/"/> <!-- IP of Machine for local testing -->
+            <cm:property name="interval" value="86400000"/> <!-- 24 hours -->
+        </cm:default-properties>
+    </cm:property-placeholder>
+
+    <reference id="dataChoicesDao" interface="org.opennms.horizon.db.dao.api.DataChoicesDao"/>
+    <reference id="sessionUtils" interface="org.opennms.horizon.db.dao.api.SessionUtils"/>
+
+    <bean id="stateManager" class="org.opennms.horizon.datachoices.internal.StateManager">
+        <property name="dataChoicesDao" ref="dataChoicesDao"/>
+        <property name="sessionUtils" ref="sessionUtils"/>
+    </bean>
+
+    <bean id="usageStatisticsReporter" class="org.opennms.horizon.datachoices.internal.UsageStatisticsReporter"
+          init-method="init" destroy-method="destroy">
+        <property name="url" value="${url}"/>
+        <property name="interval" value="${interval}"/>
+        <property name="stateManager" ref="stateManager"/>
+    </bean>
+
+    <bean id="dataChoiceRestService" class="org.opennms.horizon.datachoices.web.internal.DataChoiceRestServiceImpl">
+        <property name="stateManager" ref="stateManager"/>
+        <property name="usageStatisticsReporter" ref="usageStatisticsReporter"/>
+    </bean>
+
+    <service interface="org.opennms.horizon.datachoices.web.DataChoicesRestService" ref="dataChoiceRestService">
+        <service-properties>
+            <entry key="osgi.jaxrs.resource" value="true"/>
+        </service-properties>
+    </service>
+
+</blueprint>

--- a/platform/db/dao-api/src/main/java/org/opennms/horizon/db/dao/api/DataChoicesDao.java
+++ b/platform/db/dao-api/src/main/java/org/opennms/horizon/db/dao/api/DataChoicesDao.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.db.dao.api;
+
+import org.opennms.horizon.db.model.OnmsDataChoices;
+
+public interface DataChoicesDao extends OnmsDao<OnmsDataChoices, Integer> {
+
+    OnmsDataChoices find();
+}

--- a/platform/db/dao-impl/src/main/java/org/opennms/horizon/db/dao/impl/DataChoicesDaoHibernate.java
+++ b/platform/db/dao-impl/src/main/java/org/opennms/horizon/db/dao/impl/DataChoicesDaoHibernate.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.db.dao.impl;
+
+import org.opennms.horizon.db.dao.api.DataChoicesDao;
+import org.opennms.horizon.db.dao.api.EntityManagerHolder;
+import org.opennms.horizon.db.dao.util.AbstractDaoHibernate;
+import org.opennms.horizon.db.model.OnmsDataChoices;
+import org.springframework.util.CollectionUtils;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class DataChoicesDaoHibernate extends AbstractDaoHibernate<OnmsDataChoices, Integer> implements DataChoicesDao {
+
+    public DataChoicesDaoHibernate(EntityManagerHolder persistenceContextHolder) {
+        super(persistenceContextHolder, OnmsDataChoices.class);
+    }
+
+    @Override
+    public OnmsDataChoices find() {
+        Optional<OnmsDataChoices> dataChoicesOpt = findFirst();
+        if (dataChoicesOpt.isPresent()) {
+            return dataChoicesOpt.get();
+        }
+
+        OnmsDataChoices onmsDataChoices = new OnmsDataChoices();
+        onmsDataChoices.setSystemId(UUID.randomUUID().toString());
+        save(onmsDataChoices);
+        return onmsDataChoices;
+    }
+
+    private Optional<OnmsDataChoices> findFirst() {
+        EntityManager entityManager = getEntityManager();
+        String queryString = "SELECT d FROM " + OnmsDataChoices.class.getSimpleName() + " d";
+
+        Query query = entityManager.createQuery(queryString);
+        query.setMaxResults(1);
+
+        List resultList = query.getResultList();
+        if (CollectionUtils.isEmpty(resultList)) {
+            return Optional.empty();
+        }
+        return Optional.of((OnmsDataChoices) resultList.get(0));
+    }
+}

--- a/platform/db/dao-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/db/dao-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -95,4 +95,10 @@
 
     <service ref="interfaceToNodeCache" interface="org.opennms.horizon.db.dao.api.InterfaceToNodeCache"/>
 
+    <service interface="org.opennms.horizon.db.dao.api.DataChoicesDao">
+        <bean class="org.opennms.horizon.db.dao.impl.DataChoicesDaoHibernate">
+            <argument ref="entityManagerHolder"/>
+        </bean>
+    </service>
+
 </blueprint>

--- a/platform/db/model/src/main/java/org/opennms/horizon/db/model/OnmsDataChoices.java
+++ b/platform/db/model/src/main/java/org/opennms/horizon/db/model/OnmsDataChoices.java
@@ -36,15 +36,11 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.io.Serializable;
 
 /**
  * <p>OnmsDataChoices class.</p>
  */
-@XmlRootElement(name = "datachoices")
 @Entity
 @Table(name = "datachoices")
 public class OnmsDataChoices implements Serializable {
@@ -71,7 +67,6 @@ public class OnmsDataChoices implements Serializable {
     @SequenceGenerator(name = "datachoiceSequence", sequenceName = "datachoiceNxtId", allocationSize = 1)
     @GeneratedValue(generator = "datachoiceSequence")
     @Column(name = "datachoiceid", nullable = false)
-    @XmlAttribute(name = "id")
     public Integer getId() {
         return this.m_id;
     }
@@ -91,7 +86,6 @@ public class OnmsDataChoices implements Serializable {
      * @return a {@link String} object.
      */
     @Column(name = "systemid", length = 256, nullable = false)
-    @XmlElement(name = "systemId")
     public String getSystemId() {
         return this.m_systemId;
     }
@@ -112,7 +106,6 @@ public class OnmsDataChoices implements Serializable {
      * @return a {@link String} object.
      */
     @Column(name = "enabled", nullable = false)
-    @XmlElement(name = "enabled")
     public Boolean getEnabled() {
         return this.m_enabled;
     }

--- a/platform/db/model/src/main/java/org/opennms/horizon/db/model/OnmsDataChoices.java
+++ b/platform/db/model/src/main/java/org/opennms/horizon/db/model/OnmsDataChoices.java
@@ -1,0 +1,143 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.db.model;
+
+import com.google.common.base.MoreObjects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.io.Serializable;
+
+/**
+ * <p>OnmsDataChoices class.</p>
+ */
+@XmlRootElement(name = "datachoices")
+@Entity
+@Table(name = "datachoices")
+public class OnmsDataChoices implements Serializable {
+    private static final long serialVersionUID = 7275548439687562161L;
+
+    private Integer m_id;
+
+    private String m_systemId;
+
+    private Boolean m_enabled = false;
+
+    /**
+     * default constructor
+     */
+    public OnmsDataChoices() {
+    }
+
+    /**
+     * <p>getId</p>
+     *
+     * @return a {@link Integer} object.
+     */
+    @Id
+    @SequenceGenerator(name = "datachoiceSequence", sequenceName = "datachoiceNxtId", allocationSize = 1)
+    @GeneratedValue(generator = "datachoiceSequence")
+    @Column(name = "datachoiceid", nullable = false)
+    @XmlAttribute(name = "id")
+    public Integer getId() {
+        return this.m_id;
+    }
+
+    /**
+     * <p>setId</p>
+     *
+     * @param datachoicesid a {@link Integer} object.
+     */
+    public void setId(Integer datachoicesid) {
+        this.m_id = datachoicesid;
+    }
+
+    /**
+     * <p>getSystemId</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Column(name = "systemid", length = 256, nullable = false)
+    @XmlElement(name = "systemId")
+    public String getSystemId() {
+        return this.m_systemId;
+    }
+
+    /**
+     * <p>setSystemId</p>
+     *
+     * @param systemid a {@link String} object.
+     */
+    public void setSystemId(String systemid) {
+        this.m_systemId = systemid;
+    }
+
+
+    /**
+     * <p>getEnabled</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Column(name = "enabled", nullable = false)
+    @XmlElement(name = "enabled")
+    public Boolean getEnabled() {
+        return this.m_enabled;
+    }
+
+    /**
+     * <p>setEnabled</p>
+     *
+     * @param enabled a {@link Boolean} object.
+     */
+    public void setEnabled(Boolean enabled) {
+        this.m_enabled = enabled;
+    }
+
+
+    /**
+     * <p>toString</p>
+     *
+     * @return a {@link String} object.
+     */
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("datachoiceid", getId())
+            .add("systemid", getSystemId())
+            .add("enabled", getEnabled())
+            .toString();
+    }
+}

--- a/platform/db/schema-liquibase/src/main/liquibase/hs-0.1.0/changelog.xml
+++ b/platform/db/schema-liquibase/src/main/liquibase/hs-0.1.0/changelog.xml
@@ -8,4 +8,18 @@
             <column name="snmp_community_string" type="varchar2(32)" />
         </addColumn>
     </changeSet>
+    <changeSet author="tbigg" id="hs-0.1.0-datachoices-create-table">
+        <createSequence sequenceName="datachoicenxtid" minValue="1"/>
+        <createTable tableName="datachoices">
+            <column name="datachoiceid" type="integer">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_datachoiceid"/>
+            </column>
+            <column name="systemid" type="varchar(256)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="enabled" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>

--- a/platform/docker-it/src/test/resources-filtered/karaf/etc/org.apache.karaf.features.cfg
+++ b/platform/docker-it/src/test/resources-filtered/karaf/etc/org.apache.karaf.features.cfg
@@ -38,6 +38,7 @@ featuresBoot = \
   aries-blueprint, \
   horizon-alarms, \
   horizon-icmp, \
+  horizon-datachoices, \
   horizon-provision, \
   horizon-core-monitor, \
   horizon-minion-rest, \

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -24,7 +24,8 @@
         <module>ipc</module>
         <module>snmp</module>
         <module>provision</module>
-        
+        <module>datachoices</module>
+
         <module>assemblies</module>
         <module>docker-it</module>
         <module>inventory</module>
@@ -35,6 +36,7 @@
     </modules>
 
     <properties>
+        <display.version>${project.version}</display.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <dropwizard.metrics.version>3.1.2</dropwizard.metrics.version>
@@ -114,6 +116,7 @@
         <lombok.version>1.18.24</lombok.version>
         <mockito.version>4.5.1</mockito.version>
         <gson.version>2.8.6</gson.version>
+
     </properties>
 
     <build>
@@ -136,6 +139,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>1.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -230,6 +238,22 @@
                         <Karaf-Commands>*</Karaf-Commands>
                     </instructions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>write-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.outputDirectory}/properties-from-pom.properties</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Description
Adding initial datachoices module which will (eventually) send a payload to stats.opennms.com to a new seperate Elastic search cluster and grafana dashboard.
This has been tested with a locally deployed version of https://github.com/OpenNMS/usage-stats-handler/pull/4 which will eventually get deployed to the stats.opennms.com.

This uses the database to store the generated system ID used to identify the installation, and uses the maven project version as the version to be sent to stats.opennms.com. 

The version will need to be updated during the build and deploy pipeline using maven CLI.

Added endpoint to toggle the datachoices (Opt-In/Opt-Out) timer to run. If the datachoices has been enabled, then it will also be enabled after an application restart. The enabled flag is also stored in the database. This has been tested by restarting the k8s pod and seeing the timer running automatically.

Additional work is to follow up this PR to add more metrics into the payload, also to add the relevant endpoint to rest-server for the UI to consume.


## Jira link(s)
- https://issues.opennms.org/browse/HS-337
- https://issues.opennms.org/browse/HS-338

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
