### PR TITLE
HS-394: add alarm to PagerDuty custom details

### DIFF
--- a/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPI.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPI.java
@@ -36,6 +36,4 @@ public interface PagerDutyAPI {
     void postNotification(AlarmDTO alarm) throws NotificationException;
 
     void saveConfig(PagerDutyConfigDTO config);
-
-    void validateConfig(PagerDutyConfigDTO config) throws NotificationException;
 }

--- a/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPIImpl.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPIImpl.java
@@ -156,10 +156,8 @@ public class PagerDutyAPIImpl implements PagerDutyAPI {
             payload.getCustomDetails().putAll(customDetails);
         }
 
-        ObjectMapper mapper = new ObjectMapper();
-
         // If the event parameters contains a field called 'alarm', then the alarm itself overwrites that (by design).
-        JsonNode alarmJson = mapper.convertValue(alarm, JsonNode.class);
+        JsonNode alarmJson = objectMapper.convertValue(alarm, JsonNode.class);
         payload.getCustomDetails().put("alarm", alarmJson);
 
         event.setPayload(payload);

--- a/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPIImpl.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPIImpl.java
@@ -44,7 +44,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -65,9 +64,6 @@ public class PagerDutyAPIImpl implements PagerDutyAPI {
 
     @Autowired
     RestTemplate restTemplate;
-
-    @Autowired
-    ObjectMapper mapper;
 
     @Value("${horizon.pagerduty.client}")
     String client;
@@ -152,35 +148,34 @@ public class PagerDutyAPIImpl implements PagerDutyAPI {
         event.setClientUrl(clientURL);
 
         payload.setCustomDetails(new HashMap<>());
-        String customDetailsAlarmName = "alarm";
 
         EventDTO lastEvent = alarm.getLastEvent();
 
         if (lastEvent != null) {
             Map<String, Object> customDetails = eparmsToMap(lastEvent.getParameters());
             payload.getCustomDetails().putAll(customDetails);
-
-            customDetailsAlarmName = getCustomDetailsAlarmName(customDetailsAlarmName, customDetails);
         }
 
+        // If the event parameters contains a field called 'alarm', then we cannot
+        // add the actual alarm into the map under the same key.
+        String customDetailsAlarmName = getUniqueAlarmNameForCustomDetails("alarm", payload.getCustomDetails());
+
+        ObjectMapper mapper = new ObjectMapper();
         JsonNode alarmJson = mapper.convertValue(alarm, JsonNode.class);
         payload.getCustomDetails().put(customDetailsAlarmName, alarmJson);
 
         event.setPayload(payload);
 
-        String bodyJson = objectMapper.writeValueAsString(event);
-        return bodyJson;
+        return objectMapper.writeValueAsString(event);
     }
 
-    private String getCustomDetailsAlarmName(String customDetailsAlarmName, Map<String, Object> customDetails) {
+    private String getUniqueAlarmNameForCustomDetails(String customDetailsAlarmName, Map<String, Object> customDetails) {
         int suffix = 0;
         boolean loop = true;
-        if (customDetails == null) {
-            loop = false;
-        }
 
+        // Need to loop here in case 'alarm_1', 'alarm_2' etc is somehow in custom details as well.
         while (loop) {
-            if (customDetails.get(customDetailsAlarmName) != null) {
+            if (customDetails.containsKey(customDetailsAlarmName)) {
                 customDetailsAlarmName = "alarm_" + ++suffix;
             } else {
                 loop = false;

--- a/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPIImpl.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyAPIImpl.java
@@ -29,6 +29,7 @@
 package org.opennms.horizon.notifications.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opennms.horizon.notifications.api.dto.*;
 import org.opennms.horizon.notifications.exceptions.*;
@@ -50,6 +51,7 @@ import org.springframework.web.client.RestTemplate;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +66,9 @@ public class PagerDutyAPIImpl implements PagerDutyAPI {
     @Autowired
     RestTemplate restTemplate;
 
+    @Autowired
+    ObjectMapper mapper;
+
     @Value("${horizon.pagerduty.client}")
     String client;
 
@@ -77,10 +82,8 @@ public class PagerDutyAPIImpl implements PagerDutyAPI {
 
             String baseUrl = "https://events.pagerduty.com/v2/enqueue";
             URI uri = new URI(baseUrl);
-            String token = getAuthToken();
 
             HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", "Token token="+token);
             headers.set("Accept", "application/vnd.pagerduty+json;version=2");
             headers.set("Content-Type", "application/json");
 
@@ -102,40 +105,9 @@ public class PagerDutyAPIImpl implements PagerDutyAPI {
         pagerDutyDao.saveConfig(config);
     }
 
-    @Override
-    public void validateConfig(PagerDutyConfigDTO config) throws NotificationException {
-        callGetService(config);
-    }
-
-    private void callGetService(PagerDutyConfigDTO config) throws NotificationException {
-        try {
-            String baseUrl = "https://api.pagerduty.com/services?include%5B%5D=integrations";
-            URI uri = new URI(baseUrl);
-            String token = config.getToken();
-
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", "Token token="+token);
-            headers.set("Accept", "application/vnd.pagerduty+json;version=2");
-            headers.set("Content-Type", "application/json");
-
-            HttpEntity<String> requestEntity = new HttpEntity<>(headers);
-
-            restTemplate.exchange(uri, HttpMethod.GET, requestEntity, String.class);
-        } catch (URISyntaxException e) {
-            throw new NotificationInternalException("Bad PagerDuty validation url", e);
-        } catch (HttpClientErrorException e) {
-            throw new NotificationBadDataException("Invalid PagerDuty token");
-        }
-    }
-
     private String getPagerDutyIntegrationKey() throws NotificationConfigUninitializedException {
         PagerDutyConfigDTO config = pagerDutyDao.getConfig();
         return config.getIntegrationkey();
-    }
-
-    private String getAuthToken() throws NotificationConfigUninitializedException {
-        PagerDutyConfigDTO config = pagerDutyDao.getConfig();
-        return config.getToken();
     }
 
     private String getEvent(AlarmDTO alarm) throws NotificationConfigUninitializedException, JsonProcessingException {
@@ -179,17 +151,45 @@ public class PagerDutyAPIImpl implements PagerDutyAPI {
         event.setClient(client);
         event.setClientUrl(clientURL);
 
+        payload.setCustomDetails(new HashMap<>());
+        String customDetailsAlarmName = "alarm";
+
         EventDTO lastEvent = alarm.getLastEvent();
 
         if (lastEvent != null) {
             Map<String, Object> customDetails = eparmsToMap(lastEvent.getParameters());
-            payload.setCustomDetails(customDetails);
+            payload.getCustomDetails().putAll(customDetails);
+
+            customDetailsAlarmName = getCustomDetailsAlarmName(customDetailsAlarmName, customDetails);
         }
+
+        JsonNode alarmJson = mapper.convertValue(alarm, JsonNode.class);
+        payload.getCustomDetails().put(customDetailsAlarmName, alarmJson);
+
         event.setPayload(payload);
 
         String bodyJson = objectMapper.writeValueAsString(event);
         return bodyJson;
     }
+
+    private String getCustomDetailsAlarmName(String customDetailsAlarmName, Map<String, Object> customDetails) {
+        int suffix = 0;
+        boolean loop = true;
+        if (customDetails == null) {
+            loop = false;
+        }
+
+        while (loop) {
+            if (customDetails.get(customDetailsAlarmName) != null) {
+                customDetailsAlarmName = "alarm_" + ++suffix;
+            } else {
+                loop = false;
+            }
+        }
+
+        return customDetailsAlarmName;
+    }
+
 
     protected static Map<String, Object> eparmsToMap(List<EventParameterDTO> eparms) {
         final Map<String, Object> map = new LinkedHashMap<>();

--- a/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyDaoImpl.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/api/PagerDutyDaoImpl.java
@@ -48,14 +48,13 @@ public class PagerDutyDaoImpl implements PagerDutyDao{
 
     @Override
     public PagerDutyConfigDTO getConfig() throws NotificationConfigUninitializedException {
-        String sql = "SELECT token, integrationKey FROM pager_duty_config";
+        String sql = "SELECT integrationKey FROM pager_duty_config";
         List<PagerDutyConfigDTO> configList = null;
         try {
             configList = jdbcTemplate.query(
                 sql,
                 (rs, rowNum) ->
                     new PagerDutyConfigDTO(
-                        rs.getString("token"),
                         rs.getString("integrationKey")
                     )
             );
@@ -75,9 +74,9 @@ public class PagerDutyDaoImpl implements PagerDutyDao{
         int count = getRowCount();
 
         if (count == 0) {
-            jdbcTemplate.update("INSERT INTO pager_duty_config(token, integrationkey) VALUES(?,?)", config.getToken(), config.getIntegrationkey());
+            jdbcTemplate.update("INSERT INTO pager_duty_config(integrationkey) VALUES(?)", config.getIntegrationkey());
         } else {
-            jdbcTemplate.update("UPDATE pager_duty_config SET token=?, integrationkey=?", config.getToken(), config.getIntegrationkey());
+            jdbcTemplate.update("UPDATE pager_duty_config SET integrationkey=?", config.getIntegrationkey());
         }
     }
 

--- a/notifications/src/main/java/org/opennms/horizon/notifications/api/dto/PagerDutyConfigDTO.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/api/dto/PagerDutyConfigDTO.java
@@ -36,11 +36,9 @@ import lombok.Setter;
 public class PagerDutyConfigDTO {
     public PagerDutyConfigDTO() {
     }
-    public PagerDutyConfigDTO(String token, String integrationkey) {
-        this.token = token;
+    public PagerDutyConfigDTO(String integrationkey) {
         this.integrationkey = integrationkey;
     }
 
-    String token;
     String integrationkey;
 }

--- a/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationServiceImpl.java
+++ b/notifications/src/main/java/org/opennms/horizon/notifications/service/NotificationServiceImpl.java
@@ -48,7 +48,6 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public void postPagerDutyConfig(PagerDutyConfigDTO config) throws NotificationException {
-        pagerDutyAPI.validateConfig(config);
         pagerDutyAPI.saveConfig(config);
     }
 }

--- a/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyConfig.xml
+++ b/notifications/src/main/resources/db/changelog/hs-0.1.0/tables/pagerDutyConfig.xml
@@ -14,12 +14,6 @@
 		</preConditions> 
 
 		<createTable tableName="pager_duty_config">
-
-			<!-- token for calling PagerDuty API. -->
-			<column name="token" type="varchar(256)">
-				<constraints nullable="false" />
-			</column>
-
 			<!-- Integration key for calling PagerDuty API. -->
 			<column name="integrationkey" type="varchar(256)">
 				<constraints nullable="false" />

--- a/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyAPIImplTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyAPIImplTest.java
@@ -28,27 +28,20 @@
 
 package org.opennms.horizon.notifications.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.opennms.horizon.notifications.api.dto.PagerDutyConfigDTO;
-import org.opennms.horizon.notifications.exceptions.NotificationBadDataException;
 import org.opennms.horizon.shared.dto.event.AlarmDTO;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.web.client.HttpClientErrorException;
+import org.opennms.horizon.shared.dto.event.EventDTO;
+import org.opennms.horizon.shared.dto.event.EventParameterDTO;
 import org.springframework.web.client.RestTemplate;
 
-import java.net.URI;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
+import java.util.Arrays;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PagerDutyAPIImplTest {
@@ -59,13 +52,23 @@ public class PagerDutyAPIImplTest {
     RestTemplate restTemplate;
 
     @Mock
+    ObjectMapper mapper;
+
+    @Mock
     PagerDutyDao pagerDutyDao;
 
     @Test
     public void postNotifications() throws Exception {
         Mockito.when(pagerDutyDao.getConfig()).thenReturn(getConfigDTO());
-        AlarmDTO notificationDTO = getAlarm();
-        pagerDutyAPI.postNotification(notificationDTO);
+        AlarmDTO alarm = getAlarm(false);
+        pagerDutyAPI.postNotification(alarm);
+    }
+
+    @Test
+    public void postNotificationsWithAlarmClash() throws Exception {
+        Mockito.when(pagerDutyDao.getConfig()).thenReturn(getConfigDTO());
+        AlarmDTO alarm = getAlarm(true);
+        pagerDutyAPI.postNotification(alarm);
     }
 
     @Test
@@ -73,39 +76,25 @@ public class PagerDutyAPIImplTest {
         pagerDutyAPI.saveConfig(getConfigDTO());
     }
 
-    @Test
-    public void validateConfig() throws Exception {
-        pagerDutyAPI.validateConfig(getConfigDTO());
-    }
-
-    @Test
-    public void validateConfigInvalidToken() throws Exception {
-        doThrow(HttpClientErrorException.class)
-            .when(restTemplate).exchange(ArgumentMatchers.any(URI.class),
-                ArgumentMatchers.any(HttpMethod.class),
-                ArgumentMatchers.any(HttpEntity.class),
-                ArgumentMatchers.any(Class.class));
-
-        boolean exceptionCaught = false;
-        try{
-            pagerDutyAPI.validateConfig(getConfigDTO());
-        } catch (NotificationBadDataException e) {
-            assertEquals("Invalid PagerDuty token", e.getMessage());
-            exceptionCaught = true;
-        }
-
-        assertTrue(exceptionCaught);
-    }
-
     private PagerDutyConfigDTO getConfigDTO() {
-        return new PagerDutyConfigDTO("token", "integration_key");
+        return new PagerDutyConfigDTO("integration_key");
     }
 
-    private AlarmDTO getAlarm() {
-        AlarmDTO notificationDTO = new AlarmDTO();
-        notificationDTO.setLogMessage("Exciting message to go here");
-        notificationDTO.setReductionKey("srv01/mysql");
-        notificationDTO.setSeverity("Indeterminate");
-        return notificationDTO;
+    private AlarmDTO getAlarm(boolean includeParams) {
+        AlarmDTO alarmDTO = new AlarmDTO();
+        alarmDTO.setLogMessage("Exciting message to go here");
+        alarmDTO.setReductionKey("srv01/mysql");
+        alarmDTO.setSeverity("Indeterminate");
+
+        EventDTO lastEvent = new EventDTO();
+        if (includeParams) {
+            EventParameterDTO param = new EventParameterDTO();
+            param.setName("alarm");
+            param.setValue("value");
+
+            lastEvent.setParameters(Arrays.asList(param));
+        }
+        alarmDTO.setLastEvent(lastEvent);
+        return alarmDTO;
     }
 }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyAPIImplTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyAPIImplTest.java
@@ -52,9 +52,6 @@ public class PagerDutyAPIImplTest {
     RestTemplate restTemplate;
 
     @Mock
-    ObjectMapper mapper;
-
-    @Mock
     PagerDutyDao pagerDutyDao;
 
     @Test

--- a/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyDaoImplTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/api/PagerDutyDaoImplTest.java
@@ -64,7 +64,7 @@ public class PagerDutyDaoImplTest {
         PagerDutyConfigDTO config = getConfigDTO();
         pagerDutyDao.saveConfig(config);
 
-        Mockito.verify(jdbcTemplate, times(1)).update(anyString(), anyString(), anyString());
+        Mockito.verify(jdbcTemplate, times(1)).update(anyString(), anyString());
     }
     @Test
     public void insertConfig() throws Exception {
@@ -72,7 +72,7 @@ public class PagerDutyDaoImplTest {
         PagerDutyConfigDTO config = getConfigDTO();
         pagerDutyDao.saveConfig(config);
 
-        Mockito.verify(jdbcTemplate, times(1)).update(anyString(), anyString(), anyString());
+        Mockito.verify(jdbcTemplate, times(1)).update(anyString(), anyString());
     }
 
     @Test
@@ -90,7 +90,6 @@ public class PagerDutyDaoImplTest {
         Mockito.when(jdbcTemplate.query(any(String.class), any(RowMapper.class))).thenReturn(configs);
         PagerDutyConfigDTO config = pagerDutyDao.getConfig();
 
-        assertEquals("token", config.getToken());
         assertEquals("integration_key", config.getIntegrationkey());
     }
 
@@ -111,6 +110,6 @@ public class PagerDutyDaoImplTest {
     }
 
     private PagerDutyConfigDTO getConfigDTO() {
-        return new PagerDutyConfigDTO("token", "integration_key");
+        return new PagerDutyConfigDTO("integration_key");
     }
 }

--- a/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/kafka/AlarmKafkaConsumerIntegrationTest.java
@@ -90,12 +90,9 @@ class AlarmKafkaConsumerIntegrationTest {
     }
 
     private void setupConfig() throws NotificationException {
-        Mockito.doNothing().when(pagerDutyAPI).validateConfig(any());
-
-        String token = "unverified_token";
         String integrationKey = "not_verified";
 
-        PagerDutyConfigDTO config = new PagerDutyConfigDTO(token, integrationKey);
+        PagerDutyConfigDTO config = new PagerDutyConfigDTO(integrationKey);
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<PagerDutyConfigDTO> request = new HttpEntity<>(config, headers);
 

--- a/notifications/src/test/java/org/opennms/horizon/notifications/rest/NotificationRestControllerTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/rest/NotificationRestControllerTest.java
@@ -65,7 +65,7 @@ public class NotificationRestControllerTest {
     }
 
     private String getConfig() throws JsonProcessingException {
-        PagerDutyConfigDTO dto = new PagerDutyConfigDTO("token", "integration");
+        PagerDutyConfigDTO dto = new PagerDutyConfigDTO("integration");
 
         ObjectMapper om = new ObjectMapper();
         return om.writeValueAsString(dto);

--- a/notifications/src/test/java/org/opennms/horizon/notifications/rest/NotificationRestIntegrationTest.java
+++ b/notifications/src/test/java/org/opennms/horizon/notifications/rest/NotificationRestIntegrationTest.java
@@ -47,45 +47,25 @@ class NotificationRestIntegrationTest {
     private Integer port;
 
     @Test
-    void callSaveInvalidConfig() throws Exception {
-        Mockito.doThrow(new NotificationBadDataException("Invalid PagerDuty token")).when(pagerDutyAPI).validateConfig(any());
-
-        PagerDutyConfigDTO config = new PagerDutyConfigDTO("invalid_token", "not_verified");
-        HttpHeaders headers = new HttpHeaders();
-        HttpEntity<PagerDutyConfigDTO> request = new HttpEntity<>(config, headers);
-
-        ResponseEntity<String> response = this.testRestTemplate.postForEntity("http://localhost:" + port + "/notifications/config", request, String.class);
-
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-    }
-
-    @Test
     void callSaveConfig() throws Exception {
-        Mockito.doNothing().when(pagerDutyAPI).validateConfig(any());
-
-        String token = "unverified_token";
         String integrationKey = "not_verified";
 
-        saveConfig(token, integrationKey);
+        saveConfig(integrationKey);
     }
 
     @Test
     void callSaveConfigTwice() throws Exception {
-        Mockito.doNothing().when(pagerDutyAPI).validateConfig(any());
-
-        String token = "unverified_token";
         String integrationKey = "not_verified";
 
-        saveConfig(token, integrationKey);
+        saveConfig(integrationKey);
 
-        token = "unverified_token2";
         integrationKey = "not_verified2";
 
-        saveConfig(token, integrationKey);
+        saveConfig(integrationKey);
     }
 
-    private void saveConfig(String token, String integrationKey) {
-        PagerDutyConfigDTO config = new PagerDutyConfigDTO(token, integrationKey);
+    private void saveConfig(String integrationKey) {
+        PagerDutyConfigDTO config = new PagerDutyConfigDTO(integrationKey);
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<PagerDutyConfigDTO> request = new HttpEntity<>(config, headers);
 
@@ -94,24 +74,22 @@ class NotificationRestIntegrationTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("OK", response.getBody());
 
-        verifyConfigTable(token, integrationKey);
+        verifyConfigTable(integrationKey);
     }
 
-    private void verifyConfigTable(String token, String integrationKey) {
-        String sql = "SELECT token, integrationKey FROM pager_duty_config";
+    private void verifyConfigTable(String integrationKey) {
+        String sql = "SELECT integrationKey FROM pager_duty_config";
         List<PagerDutyConfigDTO> configList = null;
         configList = jdbcTemplate.query(
             sql,
             (rs, rowNum) ->
                 new PagerDutyConfigDTO(
-                    rs.getString("token"),
                     rs.getString("integrationKey")
                 )
         );
 
         PagerDutyConfigDTO config = configList.get(0);
 
-        assertEquals(token, config.getToken());
         assertEquals(integrationKey, config.getIntegrationkey());
     }
 }


### PR DESCRIPTION
## Description
Following Dev Jam, we added the alarm details to the PagerDuty custom details in the plugin classic uses. Also, I realised that the token I was using isn't needed. Have also removed the validation of that token also. So duplicating that work in streams.

## Jira link(s)
- https://issues.opennms.org/browse/HS-394

## Flagged for review
none

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
