### PR TITLE
[HS-409,HS-410,HS-411] Postgres authentication and converting sensitive ConfigMaps to Secrets

### DIFF
--- a/charts/opennms/templates/grafana/grafana-deployment.yaml
+++ b/charts/opennms/templates/grafana/grafana-deployment.yaml
@@ -33,8 +33,8 @@ spec:
       {{ end }}
       volumes:
         - name: grafana-config
-          configMap:
-            name: {{ .Values.Grafana.ServiceName }}
+          secret:
+            secretName: {{ .Values.Grafana.ServiceName }}
             defaultMode: 420
       containers:
         - name: {{ .Values.Grafana.ServiceName }}

--- a/charts/opennms/templates/grafana/grafana-secret.yaml
+++ b/charts/opennms/templates/grafana/grafana-secret.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret # Currently stores passwords!
 metadata:
   name: {{ .Values.Grafana.ServiceName }}
   labels:
     app: {{ .Values.Grafana.ServiceName }}
   namespace: {{ .Values.Namespace }}
-data:
+stringData:
   grafana.ini: |
     [database]
     type = postgres
@@ -365,3 +365,4 @@ data:
       "timezone": "brower",
       "title": "Horizon Stream"
     }
+type: Opaque

--- a/charts/opennms/templates/opennms/core/core-deployment.yaml
+++ b/charts/opennms/templates/opennms/core/core-deployment.yaml
@@ -58,6 +58,16 @@ spec:
                 secretKeyRef:
                   name: postgres
                   key: adminPwd
+            - name: PGSQL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: opennmsUser
+            - name: PGSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: opennmsPwd
             - name: KAFKA_BROKER_HOST
               value: "{{ .Values.Kafka.ServiceName }}"
             - name: KAFKA_BROKER_PORT

--- a/charts/opennms/templates/opennms/notification/notification-deployment.yaml
+++ b/charts/opennms/templates/opennms/notification/notification-deployment.yaml
@@ -24,6 +24,16 @@ spec:
               value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # Permanent debug port in `skaffold dev`
             - name: SPRING_KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
+            - name: SPRING_DATASOURCE_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: notificationUser
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres
+                  key: notificationPwd
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Notification.Port }}

--- a/charts/opennms/templates/postgres/postgres-cred-secret.yaml
+++ b/charts/opennms/templates/postgres/postgres-cred-secret.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     app: {{ .Values.Postgres.ServiceName }}
   namespace: {{ .Values.Namespace }}
-stringData:
-  adminUser: "pgadmin"
-  adminPwd: "{{ .Values.Postgres.AdminPassword }}"
-  opennmsUser: "opennms"
-  opennmsPwd: "{{ .Values.Postgres.OpenNMSPassword }}"
-  keycloakUser: "keycloak"
-  keycloakPwd: "{{ .Values.Postgres.KeycloakPassword }}"
-  notificationUser: "notification"
-  notificationPwd: "{{ .Values.Postgres.NotificationPassword }}"
-  grafanaUser: "grafana"
-  grafanaPwd: "{{ .Values.Postgres.GrafanaPassword }}"
+data:
+  adminUser: "{{ "pgAdmin" | b64enc }}"
+  adminPwd: "{{ .Values.Postgres.AdminPassword | b64enc }}"
+  opennmsUser: "{{ "opennms" | b64enc }}"
+  opennmsPwd: "{{ .Values.Postgres.OpenNMSPassword | b64enc }}"
+  keycloakUser: "{{ "keycloak" | b64enc }}"
+  keycloakPwd: "{{ .Values.Postgres.KeycloakPassword | b64enc }}"
+  notificationUser: "{{ "notification" | b64enc }}"
+  notificationPwd: "{{ .Values.Postgres.NotificationPassword | b64enc }}"
+  grafanaUser: "{{ "grafana" | b64enc }}"
+  grafanaPwd: "{{ .Values.Postgres.GrafanaPassword | b64enc }}"
 type: Opaque

--- a/charts/opennms/templates/postgres/postgres-deployment.yaml
+++ b/charts/opennms/templates/postgres/postgres-deployment.yaml
@@ -36,8 +36,8 @@ spec:
       volumes:
         - name: postgres-volume
         - name: postgres-initial-script
-          configMap:
-            name: postgres-initial-sql
+          secret:
+            secretName: postgres-initial-sql
       containers:
         - name: {{ .Values.Postgres.ServiceName }}
           image: {{ .Values.Postgres.Image }}

--- a/charts/opennms/templates/postgres/postgres-deployment.yaml
+++ b/charts/opennms/templates/postgres/postgres-deployment.yaml
@@ -53,8 +53,6 @@ spec:
                 secretKeyRef:
                   name: postgres
                   key: adminPwd
-            - name: POSTGRES_HOST_AUTH_METHOD
-              value: "trust"
           ports:
             - containerPort: 5432
           {{ if not .Values.TestDeploy }}

--- a/charts/opennms/templates/postgres/postgres-init-secret.yaml
+++ b/charts/opennms/templates/postgres/postgres-init-secret.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-kind: ConfigMap
+kind: Secret # Currently stores passwords!
 metadata:
   labels:
     app: {{ .Values.Postgres.ServiceName }}
   name: postgres-initial-sql
   namespace: {{ .Values.Namespace }}
-data:
+stringData:
   postgres.initial.script.sql: |
     CREATE USER opennms with password '{{ .Values.Postgres.OpenNMSPassword }}';
     CREATE DATABASE horizon_stream;
@@ -22,3 +22,4 @@ data:
     CREATE USER grafana with password '{{ .Values.Postgres.GrafanaPassword }}';
     CREATE DATABASE grafana;
     GRANT ALL ON DATABASE grafana TO grafana;
+type: Opaque

--- a/operator/internal/handlers/grafana.go
+++ b/operator/internal/handlers/grafana.go
@@ -31,7 +31,7 @@ func (h *GrafanaHandler) ProvideConfig(values values.TemplateValues) []client.Ob
 	var service corev1.Service
 	var deployment appsv1.Deployment
 
-	yaml.LoadYaml(filepath("grafana/grafana-configmap.yaml"), values, &configMap)
+	yaml.LoadYaml(filepath("grafana/grafana-secret.yaml"), values, &configMap)
 	yaml.LoadYaml(filepath("grafana/grafana-service.yaml"), values, &service)
 	yaml.LoadYaml(filepath("grafana/grafana-deployment.yaml"), values, &deployment)
 

--- a/operator/internal/handlers/postgres.go
+++ b/operator/internal/handlers/postgres.go
@@ -32,7 +32,7 @@ func (h *PostgresHandler) ProvideConfig(values values.TemplateValues) []client.O
 	var service corev1.Service
 	var deployment appsv1.Deployment
 
-	yaml.LoadYaml(filepath("postgres/postgres-init-configmap.yaml"), values, &configMap)
+	yaml.LoadYaml(filepath("postgres/postgres-init-secret.yaml"), values, &configMap)
 	yaml.LoadYaml(filepath("postgres/postgres-cred-secret.yaml"), values, &secret)
 	yaml.LoadYaml(filepath("postgres/postgres-service.yaml"), values, &service)
 	yaml.LoadYaml(filepath("postgres/postgres-deployment.yaml"), values, &deployment)

--- a/operator/internal/reconciler/values_updater.go
+++ b/operator/internal/reconciler/values_updater.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-//UpdateValues - update values for an instance based on it's crd
+// UpdateValues - update values for an instance based on it's crd
 func (r *OpenNMSReconciler) UpdateValues(ctx context.Context, instance v1alpha1.OpenNMS) values.TemplateValues {
 	if r.ValuesMap == nil {
 		r.ValuesMap = map[string]values.TemplateValues{}
@@ -55,7 +55,7 @@ func (r *OpenNMSReconciler) UpdateValues(ctx context.Context, instance v1alpha1.
 	return templateValues
 }
 
-//CheckForExistingCoreCreds - checks if core credentials already exist for a given namespace
+// CheckForExistingCoreCreds - checks if core credentials already exist for a given namespace
 func (r *OpenNMSReconciler) CheckForExistingCoreCreds(ctx context.Context, v values.TemplateValues, namespace string) (values.TemplateValues, bool) {
 	var credSecret v1.Secret
 	err := r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "keycloak-credentials"}, &credSecret)
@@ -80,7 +80,7 @@ func (r *OpenNMSReconciler) CheckForExistingCoreCreds(ctx context.Context, v val
 	return v, true
 }
 
-//CheckForExistingPostgresCreds - checks if core credentials already exist for a given namespace
+// CheckForExistingPostgresCreds - checks if core credentials already exist for a given namespace
 func (r *OpenNMSReconciler) CheckForExistingPostgresCreds(ctx context.Context, v values.TemplateValues, namespace string) (values.TemplateValues, bool) {
 	var credSecret v1.Secret
 	err := r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: "postgres"}, &credSecret)
@@ -101,7 +101,7 @@ func (r *OpenNMSReconciler) CheckForExistingPostgresCreds(ctx context.Context, v
 	return v, true
 }
 
-//setCorePasswords - sets randomly generated passwords for the core if not already set
+// setCorePasswords - sets randomly generated passwords for the core if not already set
 func setCorePasswords(tv values.TemplateValues, creds v1alpha1.Credentials) values.TemplateValues {
 	if creds.AdminPassword == "" {
 		tv.Values.Keycloak.AdminPassword = security.GeneratePassword(false)
@@ -121,12 +121,12 @@ func setCorePasswords(tv values.TemplateValues, creds v1alpha1.Credentials) valu
 	return tv
 }
 
-//setCorePasswords - sets randomly generated password for Postgres if not already set
+// setCorePasswords - sets randomly generated password for Postgres if not already set
 func setPostgresPassword(tv values.TemplateValues) values.TemplateValues {
-	tv.Values.Postgres.AdminPassword = security.GeneratePassword(false)
-	tv.Values.Postgres.OpenNMSPassword = security.GeneratePassword(false)
-	tv.Values.Postgres.KeycloakPassword = security.GeneratePassword(false)
-	tv.Values.Postgres.NotificationPassword = security.GeneratePassword(false)
-	tv.Values.Postgres.GrafanaPassword = security.GeneratePassword(false)
+	tv.Values.Postgres.AdminPassword = security.GeneratePassword(true)
+	tv.Values.Postgres.OpenNMSPassword = security.GeneratePassword(true)
+	tv.Values.Postgres.KeycloakPassword = security.GeneratePassword(true)
+	tv.Values.Postgres.NotificationPassword = security.GeneratePassword(true)
+	tv.Values.Postgres.GrafanaPassword = security.GeneratePassword(true)
 	return tv
 }

--- a/platform/alarms/itests/src/test/java/org/opennms/horizon/alarms/itests/CoreContainer.java
+++ b/platform/alarms/itests/src/test/java/org/opennms/horizon/alarms/itests/CoreContainer.java
@@ -57,6 +57,8 @@ public class CoreContainer extends GenericContainer<CoreContainer> implements Te
                 .withEnv("PGSQL_SERVICE_NAME", DB_ALIAS)
                 .withEnv("PGSQL_ADMIN_USERNAME", pgContainer.getUsername())
                 .withEnv("PGSQL_ADMIN_PASSWORD", pgContainer.getPassword())
+                .withEnv("PGSQL_USERNAME", pgContainer.getUsername())
+                .withEnv("PGSQL_PASSWORD", pgContainer.getPassword())
                 .withEnv("KAFKA_BROKER_HOST", KAFKA_ALIAS)
                 .withEnv("KAFKA_BROKER_PORT", KAFKA_PORT.toString())
                 .withEnv("NOTIFICATION_KAFKA_TOPIC", NOTIFICATION_KAFKA_TOPIC.toString())

--- a/platform/db/schema/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/db/schema/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -57,8 +57,8 @@
             <cm:property name="datasource.adminPassword" value="$[env:PGSQL_ADMIN_PASSWORD]" />
 
             <cm:property name="datasource.url" value="jdbc:postgresql://$[env:PGSQL_SERVICE_NAME]:5432/opennms" />
-            <cm:property name="datasource.username" value="opennms" />
-            <cm:property name="datasource.password" value="" />
+            <cm:property name="datasource.username" value="$[env:PGSQL_USERNAME]" />
+            <cm:property name="datasource.password" value="$[env:PGSQL_PASSWORD]" />
             <cm:property name="datasource.databaseName" value="opennms" />
             <cm:property name="datasource.initialize" value="true" />
 

--- a/platform/docker-it/pom.xml
+++ b/platform/docker-it/pom.xml
@@ -297,6 +297,8 @@
                   <PGSQL_SERVICE_NAME>postgres-host</PGSQL_SERVICE_NAME>
                   <PGSQL_ADMIN_USERNAME>postgres</PGSQL_ADMIN_USERNAME>
                   <PGSQL_ADMIN_PASSWORD>unused</PGSQL_ADMIN_PASSWORD>
+                  <PGSQL_USERNAME>opennms</PGSQL_USERNAME>
+                  <PGSQL_PASSWORD>unused</PGSQL_PASSWORD>
                   <KAFKA_BROKER_HOST>kafka-host</KAFKA_BROKER_HOST>
                   <KAFKA_BROKER_PORT>9092</KAFKA_BROKER_PORT>
                   <NOTIFICATION_KAFKA_TOPIC>org.opennms.horizon.notifications.alarms</NOTIFICATION_KAFKA_TOPIC>


### PR DESCRIPTION
…atabase passwords into Secrets

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- Enables authentication against Postgres
- Converts ConfigMaps to Secrets where they contain passwords
- Allows Operator to use special characters when generating Postgres passwords

## Jira link(s)
- https://issues.opennms.org/browse/HS-409
- https://issues.opennms.org/browse/HS-410
- https://issues.opennms.org/browse/HS-411

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
