### PR TITLE
HS-339: Stats: Implement Phase 1 Metrics collection

### DIFF
--- a/platform/datachoices/pom.xml
+++ b/platform/datachoices/pom.xml
@@ -42,5 +42,17 @@
             <artifactId>common-web</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/platform/datachoices/pom.xml
+++ b/platform/datachoices/pom.xml
@@ -54,5 +54,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>2.6.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
@@ -34,6 +34,8 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 import javax.ws.rs.InternalServerErrorException;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.HashMap;
+import java.util.Map;
 
 @XmlRootElement
 public class UsageStatisticsReportDTO {
@@ -43,6 +45,10 @@ public class UsageStatisticsReportDTO {
     private String version;
 
     private long nodes;
+
+    private long monitoredServices;
+
+    private Map<String, Integer> deviceTypeCounts = new HashMap<>();
 
     public String getSystemId() {
         return this.systemId;
@@ -66,6 +72,22 @@ public class UsageStatisticsReportDTO {
 
     public void setNodes(long nodes) {
         this.nodes = nodes;
+    }
+
+    public long getMonitoredServices() {
+        return monitoredServices;
+    }
+
+    public void setMonitoredServices(long monitoredServices) {
+        this.monitoredServices = monitoredServices;
+    }
+
+    public Map<String, Integer> getDeviceTypeCounts() {
+        return deviceTypeCounts;
+    }
+
+    public void setDeviceTypeCounts(Map<String, Integer> deviceTypeCounts) {
+        this.deviceTypeCounts = deviceTypeCounts;
     }
 
     public String toJson() {

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
@@ -42,6 +42,8 @@ public class UsageStatisticsReportDTO {
 
     private String version;
 
+    private long nodes;
+
     public String getSystemId() {
         return this.systemId;
     }
@@ -56,6 +58,14 @@ public class UsageStatisticsReportDTO {
 
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    public long getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(long nodes) {
+        this.nodes = nodes;
     }
 
     public String toJson() {

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTO.java
@@ -39,7 +39,6 @@ import java.util.Map;
 
 @XmlRootElement
 public class UsageStatisticsReportDTO {
-
     private String systemId;
 
     private String version;

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/DataChoicesTimerTask.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/DataChoicesTimerTask.java
@@ -1,0 +1,48 @@
+package org.opennms.horizon.datachoices.internal;
+
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.opennms.core.web.HttpClientWrapper;
+import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.TimerTask;
+
+public class DataChoicesTimerTask extends TimerTask {
+    private static final Logger LOG = LoggerFactory.getLogger(DataChoicesTimerTask.class);
+
+    private static final String USAGE_REPORT = "hs-usage-report";
+
+    private final UsageStatisticsReporter reporter;
+
+    private final String url;
+
+    public DataChoicesTimerTask(UsageStatisticsReporter reporter, String url) {
+        this.reporter = reporter;
+        this.url = url;
+    }
+
+    @Override
+    public void run() {
+        UsageStatisticsReportDTO usageStatsReport = reporter.generateReport();
+        String usageStatsReportJson = usageStatsReport.toJson();
+
+        try (HttpClientWrapper clientWrapper = HttpClientWrapper.create();
+             CloseableHttpClient client = clientWrapper.getClient()) {
+
+            HttpPost httpRequest = new HttpPost(url + USAGE_REPORT);
+            httpRequest.setEntity(new StringEntity(usageStatsReportJson, ContentType.APPLICATION_JSON));
+
+            LOG.info("Sending usage statistics report to {}: {}", httpRequest.getURI(), usageStatsReportJson);
+            client.execute(httpRequest);
+            LOG.info("Successfully sent usage statistics report.");
+
+        } catch (IOException e) {
+            LOG.error("The usage statistics report was not successfully delivered", e);
+        }
+    }
+}

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
@@ -35,6 +35,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.opennms.core.web.HttpClientWrapper;
 import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
 import org.opennms.horizon.datachoices.internal.StateManager.StateChangeHandler;
+import org.opennms.horizon.db.dao.api.NodeDao;
 import org.opennms.horizon.db.model.OnmsDataChoices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,8 @@ public class UsageStatisticsReporter implements StateChangeHandler {
     private static final String USAGE_REPORT = "hs-usage-report";
 
     private StateManager stateManager;
+
+    private NodeDao nodeDao;
 
     private String url;
 
@@ -101,6 +104,8 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         usageStatsReport.setSystemId(dataChoices.getSystemId());
         usageStatsReport.setVersion(getVersion());
 
+        usageStatsReport.setNodes(nodeDao.countAll());
+
         return usageStatsReport;
     }
 
@@ -129,6 +134,10 @@ public class UsageStatisticsReporter implements StateChangeHandler {
 
     public void setStateManager(StateManager stateManager) {
         this.stateManager = stateManager;
+    }
+
+    public void setNodeDao(NodeDao nodeDao) {
+        this.nodeDao = nodeDao;
     }
 
     private class DataChoicesTimerTask extends TimerTask {

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
@@ -28,11 +28,6 @@
 
 package org.opennms.horizon.datachoices.internal;
 
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.opennms.core.web.HttpClientWrapper;
 import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
 import org.opennms.horizon.datachoices.internal.StateManager.StateChangeHandler;
 import org.opennms.horizon.db.dao.api.MonitoredServiceDao;
@@ -47,17 +42,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Timer;
-import java.util.TimerTask;
 
 public class UsageStatisticsReporter implements StateChangeHandler {
     private static final Logger LOG = LoggerFactory.getLogger(UsageStatisticsReporter.class);
     private static final String POM_PROPERTIES_FILE_NAME = "properties-from-pom.properties";
     private static final String DISPLAY_VERSION = "display.version";
-    private static final String USAGE_REPORT = "hs-usage-report";
 
     private StateManager stateManager;
 
@@ -104,7 +96,9 @@ public class UsageStatisticsReporter implements StateChangeHandler {
     public synchronized void schedule() {
         LOG.info("Scheduling usage statistics report every {} ms", interval);
         timer = new Timer();
-        timer.schedule(new DataChoicesTimerTask(), 0, interval);
+
+        DataChoicesTimerTask timerTask = new DataChoicesTimerTask(this, url);
+        timer.schedule(timerTask, 0, interval);
     }
 
     public UsageStatisticsReportDTO generateReport() {
@@ -119,7 +113,7 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         return usageStatsReport;
     }
 
-    private void setUsageStatsReport(UsageStatisticsReportDTO usageStatsReport) {
+    protected void setUsageStatsReport(UsageStatisticsReportDTO usageStatsReport) {
         usageStatsReport.setNodes(nodeDao.countAll());
         usageStatsReport.setMonitoredServices(monitoredServiceDao.countAll());
         usageStatsReport.setDeviceTypeCounts(getDeviceTypeCounts());
@@ -184,28 +178,5 @@ public class UsageStatisticsReporter implements StateChangeHandler {
 
     public void setMonitoredServiceDao(MonitoredServiceDao monitoredServiceDao) {
         this.monitoredServiceDao = monitoredServiceDao;
-    }
-
-    private class DataChoicesTimerTask extends TimerTask {
-
-        @Override
-        public void run() {
-            UsageStatisticsReportDTO usageStatsReport = generateReport();
-            String usageStatsReportJson = usageStatsReport.toJson();
-
-            try (HttpClientWrapper clientWrapper = HttpClientWrapper.create();
-                 CloseableHttpClient client = clientWrapper.getClient()) {
-
-                HttpPost httpRequest = new HttpPost(url + USAGE_REPORT);
-                httpRequest.setEntity(new StringEntity(usageStatsReportJson, ContentType.APPLICATION_JSON));
-
-                LOG.info("Sending usage statistics report to {}: {}", httpRequest.getURI(), usageStatsReportJson);
-                client.execute(httpRequest);
-                LOG.info("Successfully sent usage statistics report.");
-
-            } catch (IOException e) {
-                LOG.error("The usage statistics report was not successfully delivered", e);
-            }
-        }
     }
 }

--- a/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
+++ b/platform/datachoices/src/main/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporter.java
@@ -35,14 +35,20 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.opennms.core.web.HttpClientWrapper;
 import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
 import org.opennms.horizon.datachoices.internal.StateManager.StateChangeHandler;
+import org.opennms.horizon.db.dao.api.MonitoredServiceDao;
 import org.opennms.horizon.db.dao.api.NodeDao;
+import org.opennms.horizon.db.dao.api.SessionUtils;
 import org.opennms.horizon.db.model.OnmsDataChoices;
+import org.opennms.horizon.db.model.OnmsNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -55,7 +61,11 @@ public class UsageStatisticsReporter implements StateChangeHandler {
 
     private StateManager stateManager;
 
+    private SessionUtils sessionUtils;
+
     private NodeDao nodeDao;
+
+    private MonitoredServiceDao monitoredServiceDao;
 
     private String url;
 
@@ -104,9 +114,37 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         usageStatsReport.setSystemId(dataChoices.getSystemId());
         usageStatsReport.setVersion(getVersion());
 
-        usageStatsReport.setNodes(nodeDao.countAll());
+        sessionUtils.withReadOnlyTransaction(() -> setUsageStatsReport(usageStatsReport));
 
         return usageStatsReport;
+    }
+
+    private void setUsageStatsReport(UsageStatisticsReportDTO usageStatsReport) {
+        usageStatsReport.setNodes(nodeDao.countAll());
+        usageStatsReport.setMonitoredServices(monitoredServiceDao.countAll());
+        usageStatsReport.setDeviceTypeCounts(getDeviceTypeCounts());
+    }
+
+    /*
+     * Counting the number of occurrences of a string.
+     *
+     * Currently this takes the node label as the DeviceType as this field is currently not available.
+     * TODO: Update to a DeviceType (ie. router, server, storage) when available
+     */
+    private Map<String, Integer> getDeviceTypeCounts() {
+        Map<String, Integer> deviceTypeCounts = new HashMap<>();
+
+        for (OnmsNode node : nodeDao.findAll()) {
+            String deviceType = node.getLabel();
+            if (deviceTypeCounts.containsKey(deviceType)) {
+                int currentCount = deviceTypeCounts.get(deviceType);
+                deviceTypeCounts.put(deviceType, ++currentCount);
+            } else {
+                deviceTypeCounts.put(deviceType, 1);
+            }
+        }
+
+        return deviceTypeCounts;
     }
 
     private String getVersion() {
@@ -136,8 +174,16 @@ public class UsageStatisticsReporter implements StateChangeHandler {
         this.stateManager = stateManager;
     }
 
+    public void setSessionUtils(SessionUtils sessionUtils) {
+        this.sessionUtils = sessionUtils;
+    }
+
     public void setNodeDao(NodeDao nodeDao) {
         this.nodeDao = nodeDao;
+    }
+
+    public void setMonitoredServiceDao(MonitoredServiceDao monitoredServiceDao) {
+        this.monitoredServiceDao = monitoredServiceDao;
     }
 
     private class DataChoicesTimerTask extends TimerTask {

--- a/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,13 +11,15 @@
     <cm:property-placeholder persistent-id="org.opennms.horizon.datachoices">
         <cm:default-properties>
 <!--            Note: to test this with a local version of UsageStatsHandler, use the IP of your machine to connect to it outside the l8s cluster -->
-            <cm:property name="url" value="http://stats.opennms.com/"/>
-            <cm:property name="interval" value="86400000"/> <!-- 24 hours -->
+            <cm:property name="url" value="http://192.168.1.90:3542/"/>
+<!--            <cm:property name="interval" value="86400000"/> &lt;!&ndash; 24 hours &ndash;&gt;-->
+            <cm:property name="interval" value="30000"/> <!-- 24 hours -->
         </cm:default-properties>
     </cm:property-placeholder>
 
     <reference id="dataChoicesDao" interface="org.opennms.horizon.db.dao.api.DataChoicesDao"/>
     <reference id="sessionUtils" interface="org.opennms.horizon.db.dao.api.SessionUtils"/>
+    <reference id="nodeDao" interface="org.opennms.horizon.db.dao.api.NodeDao" />
 
     <bean id="stateManager" class="org.opennms.horizon.datachoices.internal.StateManager">
         <property name="dataChoicesDao" ref="dataChoicesDao"/>
@@ -29,6 +31,7 @@
         <property name="url" value="${url}"/>
         <property name="interval" value="${interval}"/>
         <property name="stateManager" ref="stateManager"/>
+        <property name="nodeDao" ref="nodeDao"/>
     </bean>
 
     <bean id="dataChoiceRestService" class="org.opennms.horizon.datachoices.web.internal.DataChoiceRestServiceImpl">

--- a/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,6 +20,7 @@
     <reference id="dataChoicesDao" interface="org.opennms.horizon.db.dao.api.DataChoicesDao"/>
     <reference id="sessionUtils" interface="org.opennms.horizon.db.dao.api.SessionUtils"/>
     <reference id="nodeDao" interface="org.opennms.horizon.db.dao.api.NodeDao" />
+    <reference id="monitoredServiceDao" interface="org.opennms.horizon.db.dao.api.MonitoredServiceDao" />
 
     <bean id="stateManager" class="org.opennms.horizon.datachoices.internal.StateManager">
         <property name="dataChoicesDao" ref="dataChoicesDao"/>
@@ -31,7 +32,9 @@
         <property name="url" value="${url}"/>
         <property name="interval" value="${interval}"/>
         <property name="stateManager" ref="stateManager"/>
+        <property name="sessionUtils" ref="sessionUtils"/>
         <property name="nodeDao" ref="nodeDao"/>
+        <property name="monitoredServiceDao" ref="monitoredServiceDao"/>
     </bean>
 
     <bean id="dataChoiceRestService" class="org.opennms.horizon.datachoices.web.internal.DataChoiceRestServiceImpl">

--- a/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/datachoices/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,9 +11,8 @@
     <cm:property-placeholder persistent-id="org.opennms.horizon.datachoices">
         <cm:default-properties>
 <!--            Note: to test this with a local version of UsageStatsHandler, use the IP of your machine to connect to it outside the l8s cluster -->
-            <cm:property name="url" value="http://192.168.1.90:3542/"/>
-<!--            <cm:property name="interval" value="86400000"/> &lt;!&ndash; 24 hours &ndash;&gt;-->
-            <cm:property name="interval" value="30000"/> <!-- 24 hours -->
+            <cm:property name="url" value="http://stats.opennms.com/"/>
+            <cm:property name="interval" value="86400000"/> <!-- 24 hours -->
         </cm:default-properties>
     </cm:property-placeholder>
 

--- a/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTOTest.java
+++ b/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/dto/UsageStatisticsReportDTOTest.java
@@ -1,0 +1,33 @@
+package org.opennms.horizon.datachoices.dto;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UsageStatisticsReportDTOTest {
+    private static final String TEST_DEVICE_TYPE = "device";
+    private static final int TEST_DEVICE_TYPE_COUNT = 1;
+    private static final String TEST_SYSTEM_ID = "1234";
+    private static final String TEST_VERSION = "1.0.0";
+    private static final int TEST_NODE_COUNT = 1;
+    private static final int TEST_MONITORED_SERVICES = 2;
+
+    @Test
+    public void testToJson() {
+        UsageStatisticsReportDTO report = new UsageStatisticsReportDTO();
+        report.setSystemId(TEST_SYSTEM_ID);
+        report.setVersion(TEST_VERSION);
+        report.setNodes(TEST_NODE_COUNT);
+        report.setMonitoredServices(TEST_MONITORED_SERVICES);
+        report.setDeviceTypeCounts(Collections.singletonMap(TEST_DEVICE_TYPE, TEST_DEVICE_TYPE_COUNT));
+
+        String json = report.toJson();
+        assertEquals("{\"systemId\":\"" + TEST_SYSTEM_ID + "\",\"version\":\"" + TEST_VERSION + "\"," + "\"nodes\":" + TEST_NODE_COUNT + "," +
+            "\"monitoredServices\":" + TEST_MONITORED_SERVICES + ",\"deviceTypeCounts\":{\"" + TEST_DEVICE_TYPE + "\":" + TEST_DEVICE_TYPE_COUNT + "}}", json);
+    }
+}

--- a/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/internal/DataChoicesTimerTaskTest.java
+++ b/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/internal/DataChoicesTimerTaskTest.java
@@ -1,0 +1,58 @@
+package org.opennms.horizon.datachoices.internal;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
+
+import java.util.Collections;
+
+public class DataChoicesTimerTaskTest {
+    private static final String TEST_DEVICE_TYPE = "device";
+    private static final int TEST_DEVICE_TYPE_COUNT = 1;
+    private static final String TEST_SYSTEM_ID = "1234";
+    private static final String TEST_VERSION = "1.0.0";
+    private static final int TEST_NODE_COUNT = 1;
+    private static final int TEST_MONITORED_SERVICES = 2;
+
+    private static final int TEST_PORT = 55555;
+
+    private DataChoicesTimerTask timerTask;
+
+    @Mock
+    private UsageStatisticsReporter reporter;
+
+    @Before
+    public void setup() {
+        timerTask = new DataChoicesTimerTask(reporter, "http://localhost:" + TEST_PORT);
+    }
+
+    @Test
+    public void testRun() {
+
+        UsageStatisticsReportDTO report = getReport();
+        String json = report.toJson();
+
+        System.out.println("json = " + json);
+
+
+//        stubFor(WireMock.any(WireMock.urlPathEqualTo("/hs-usage-report"))
+//            .withRequestBody(WireMock.equalToJson(json))
+//            .willReturn(WireMock.ok()));
+
+//        UsageStatisticsReportDTO report = getReport();
+//        when(reporter.generateReport()).thenReturn(report);
+//
+//        timerTask.run();
+    }
+
+    private static UsageStatisticsReportDTO getReport() {
+        UsageStatisticsReportDTO report = new UsageStatisticsReportDTO();
+        report.setSystemId(TEST_SYSTEM_ID);
+        report.setVersion(TEST_VERSION);
+        report.setNodes(TEST_NODE_COUNT);
+        report.setMonitoredServices(TEST_MONITORED_SERVICES);
+        report.setDeviceTypeCounts(Collections.singletonMap(TEST_DEVICE_TYPE, TEST_DEVICE_TYPE_COUNT));
+        return report;
+    }
+}

--- a/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/internal/StateManagerTest.java
+++ b/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/internal/StateManagerTest.java
@@ -1,0 +1,72 @@
+package org.opennms.horizon.datachoices.internal;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.horizon.db.dao.api.DataChoicesDao;
+import org.opennms.horizon.db.dao.api.SessionUtils;
+import org.opennms.horizon.db.model.OnmsDataChoices;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StateManagerTest {
+
+    @InjectMocks
+    private StateManager stateManager;
+
+    @Mock
+    private DataChoicesDao dataChoicesDao;
+
+    @Mock
+    private StateManager.StateChangeHandler callback;
+
+    private static OnmsDataChoices getOnmsDataChoices() {
+        OnmsDataChoices dataChoices = new OnmsDataChoices();
+        dataChoices.setId(1);
+        dataChoices.setEnabled(false);
+        dataChoices.setSystemId(UUID.randomUUID().toString());
+        return dataChoices;
+    }
+
+    @Before
+    public void setup() {
+        stateManager.setSessionUtils(new TestNoOpSessionUtils());
+        stateManager.onIsEnabledChanged(callback);
+    }
+
+    @Test
+    public void testSetEnabled() {
+        OnmsDataChoices dataChoices = getOnmsDataChoices();
+        when(dataChoicesDao.find()).thenReturn(dataChoices);
+
+        stateManager.setEnabled(true);
+
+        verify(callback, times(1))
+            .onEnabledChanged(true);
+
+        assertTrue(dataChoices.getEnabled());
+    }
+
+    private static class TestNoOpSessionUtils implements SessionUtils {
+
+        @Override
+        public <V> V withTransaction(Supplier<V> supplier) {
+            return supplier.get();
+        }
+
+        @Override
+        public <V> V withReadOnlyTransaction(Supplier<V> supplier) {
+            return supplier.get();
+        }
+    }
+}

--- a/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporterTest.java
+++ b/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/internal/UsageStatisticsReporterTest.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.horizon.datachoices.internal;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
+import org.opennms.horizon.db.dao.api.MonitoredServiceDao;
+import org.opennms.horizon.db.dao.api.NodeDao;
+import org.opennms.horizon.db.dao.api.SessionUtils;
+import org.opennms.horizon.db.model.OnmsDataChoices;
+import org.opennms.horizon.db.model.OnmsNode;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UsageStatisticsReporterTest {
+    private static final long TEST_NODE_DAO_COUNT = 2;
+    private static final long TEST_MONITORED_SERVICE_DAO_COUNT = 3;
+    private static final int TEST_NODE_ID = 123;
+    private static final String TEST_NODE_LABEL = "node-label";
+    private static final long TEST_INTERVAL = 100L;
+    private static final int TEST_NODE_COUNT = 1;
+
+    @InjectMocks
+    private UsageStatisticsReporter reporter;
+
+    @Mock
+    private StateManager stateManager;
+
+    @Mock
+    private SessionUtils sessionUtils;
+
+    @Mock
+    private NodeDao nodeDao;
+
+    @Mock
+    private MonitoredServiceDao monitoredServiceDao;
+
+    private static OnmsDataChoices getOnmsDataChoices(boolean enabled) {
+        OnmsDataChoices dataChoices = new OnmsDataChoices();
+        dataChoices.setId(1);
+        dataChoices.setEnabled(enabled);
+        dataChoices.setSystemId(UUID.randomUUID().toString());
+        return dataChoices;
+    }
+
+    @Before
+    public void setup() {
+        reporter.setInterval(TEST_INTERVAL);
+    }
+
+    @Test
+    public void testInitEnabled() {
+        OnmsDataChoices dataChoices = getOnmsDataChoices(true);
+        when(stateManager.getDataChoices()).thenReturn(dataChoices);
+
+        reporter.init();
+
+        verify(stateManager, times(1))
+            .onIsEnabledChanged(any(StateManager.StateChangeHandler.class));
+    }
+
+    @Test
+    public void testInitDisabled() {
+        OnmsDataChoices dataChoices = getOnmsDataChoices(false);
+        when(stateManager.getDataChoices()).thenReturn(dataChoices);
+
+        reporter.init();
+
+        verify(stateManager, times(1))
+            .onIsEnabledChanged(any(StateManager.StateChangeHandler.class));
+    }
+
+    @Test
+    public void testDestroy() {
+        OnmsDataChoices dataChoices = getOnmsDataChoices(true);
+        when(stateManager.getDataChoices()).thenReturn(dataChoices);
+
+        reporter.init();
+        reporter.destroy();
+
+        assertTrue(true);
+    }
+
+    @Test
+    public void testGenerateReport() {
+        boolean enabled = true;
+        OnmsDataChoices dataChoices = getOnmsDataChoices(enabled);
+        when(stateManager.getDataChoices()).thenReturn(dataChoices);
+
+        UsageStatisticsReportDTO report = reporter.generateReport();
+        assertEquals(dataChoices.getSystemId(), report.getSystemId());
+        assertEquals(1, dataChoices.getId().intValue());
+        assertEquals(dataChoices.getEnabled(), enabled);
+    }
+
+    @Test
+    public void testSetUsageStatsReport() {
+        when(nodeDao.countAll()).thenReturn(TEST_NODE_DAO_COUNT);
+        when(monitoredServiceDao.countAll()).thenReturn(TEST_MONITORED_SERVICE_DAO_COUNT);
+
+        OnmsNode node = new OnmsNode();
+        node.setId(TEST_NODE_ID);
+        node.setLabel(TEST_NODE_LABEL);
+
+        when(nodeDao.findAll()).thenReturn(Collections.singletonList(node));
+
+        UsageStatisticsReportDTO report = new UsageStatisticsReportDTO();
+        reporter.setUsageStatsReport(report);
+
+        assertEquals(TEST_NODE_DAO_COUNT, report.getNodes());
+        assertEquals(TEST_MONITORED_SERVICE_DAO_COUNT, report.getMonitoredServices());
+
+        Map<String, Integer> deviceTypeCounts = report.getDeviceTypeCounts();
+        assertEquals(1, deviceTypeCounts.size());
+
+        Map.Entry<String, Integer> entry = deviceTypeCounts
+            .entrySet().stream().iterator().next();
+
+        assertEquals(TEST_NODE_LABEL, entry.getKey());
+        assertEquals(TEST_NODE_COUNT, entry.getValue().intValue());
+    }
+}

--- a/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/web/internal/DataChoiceRestServiceImplTest.java
+++ b/platform/datachoices/src/test/java/org/opennms/horizon/datachoices/web/internal/DataChoiceRestServiceImplTest.java
@@ -1,0 +1,46 @@
+package org.opennms.horizon.datachoices.web.internal;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.horizon.datachoices.dto.UsageStatisticsReportDTO;
+import org.opennms.horizon.datachoices.internal.StateManager;
+import org.opennms.horizon.datachoices.internal.UsageStatisticsReporter;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataChoiceRestServiceImplTest {
+
+    @InjectMocks
+    private DataChoiceRestServiceImpl dataChoiceRestService;
+
+    @Mock
+    private StateManager stateManager;
+
+    @Mock
+    private UsageStatisticsReporter usageStatisticsReporter;
+
+    @Test
+    public void testGetUsageStatistics() {
+        UsageStatisticsReportDTO report = new UsageStatisticsReportDTO();
+        report.setSystemId(UUID.randomUUID().toString());
+
+        Mockito.when(usageStatisticsReporter.generateReport()).thenReturn(report);
+
+        UsageStatisticsReportDTO returnUsageStats = dataChoiceRestService.getUsageStatistics();
+        assertEquals(report.getSystemId(), returnUsageStats.getSystemId());
+    }
+
+    @Test
+    public void testToggleUsageStatistics() {
+        dataChoiceRestService.toggleUsageStatistics(true);
+        assertTrue(true);
+    }
+}

--- a/platform/db/dao-api/src/main/java/org/opennms/horizon/db/dao/api/MonitoredServiceDao.java
+++ b/platform/db/dao-api/src/main/java/org/opennms/horizon/db/dao/api/MonitoredServiceDao.java
@@ -2,7 +2,7 @@
  * This file is part of OpenNMS(R).
  *
  * Copyright (C) 2002-2014 The OpenNMS Group, Inc.
- * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
  *
  * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
  *
@@ -28,12 +28,10 @@
 
 package org.opennms.horizon.db.dao.api;
 
-import org.opennms.horizon.db.model.OnmsApplication;
 import org.opennms.horizon.db.model.OnmsMonitoredService;
 
 import java.net.InetAddress;
 import java.util.List;
-import java.util.Set;
 
 /**
  * <p>MonitoredServiceDao interface.</p>

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -102,7 +102,7 @@ portForward:
   - resourceType: deployment
     resourceName: my-postgres
     port: 5432 # Postgres
-    localPort: 5432
+    localPort: 15432
   - resourceType: deployment
     resourceName: prometheus
     port: 9090 # prometheus tcp

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -102,7 +102,7 @@ portForward:
   - resourceType: deployment
     resourceName: my-postgres
     port: 5432 # Postgres
-    localPort: 15432
+    localPort: 5432
   - resourceType: deployment
     resourceName: prometheus
     port: 9090 # prometheus tcp


### PR DESCRIPTION
## Description
Implementing the metrics collection for Phase 1. 
Also adding more tests of this datachoices module.

This has been tested with https://github.com/OpenNMS/usage-stats-handler/pull/4 to show the following dashboard: 
![image](https://user-images.githubusercontent.com/8379423/192498107-f6741fc1-9fc3-435e-a613-27ee602e75cb.png)
(Has been ran multiple times in testing, hence why multiple installs)
This is to be deployed to stats.opennms.com at some point in the future.

* Monitored Services shows 0 because currently we do not write to the `ifServices` yet.
* Currently the deviceType is of the node label until we have a way to get a device type (i.e. Router, Server, Storage)

Still TODO:
* BFF endpoint for frontend
* Frontend button to Opt-In/Out

## Jira link(s)
- https://issues.opennms.org/browse/HS-339

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [x] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
