### PR TITLE
Add missing env var to Core deployment in k8s manifest

### DIFF
--- a/dev/kubernetes.kafka.yaml
+++ b/dev/kubernetes.kafka.yaml
@@ -624,6 +624,10 @@ spec:
                 secretKeyRef:
                   name: postgres-admin-secret
                   key: password
+            - name: PGSQL_USERNAME
+              value: "opennms"
+            - name: PGSQL_PASSWORD
+              value: ""
             - name: KAFKA_BROKER_HOST
               value: "kafka"
             - name: KAFKA_BROKER_PORT


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- Missing env var in the core deployment broke initial startup

## Jira link(s)
- none

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
