### PR TITLE
Adjustment of routing code, include missing location/system message

### DIFF
--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/router/MinionLookupService.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/router/MinionLookupService.java
@@ -1,6 +1,6 @@
 package org.opennms.miniongateway.router;
 
-import java.util.Queue;
+import java.util.List;
 import java.util.UUID;
 import org.opennms.horizon.shared.ipc.grpc.server.manager.MinionManagerListener;
 
@@ -10,5 +10,11 @@ public interface MinionLookupService extends MinionManagerListener {
 
     UUID findGatewayNodeWithId(String id);
 
-    Queue<UUID> findGatewayNodeWithLocation(String location);
+    /**
+     * Returns list of minions assigned to given location.
+     *
+     * @param location Location name.
+     * @return Minions assigned to location or null if none found.
+     */
+    List<UUID> findGatewayNodeWithLocation(String location);
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/router/MinionLookupServiceImpl.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/router/MinionLookupServiceImpl.java
@@ -1,5 +1,6 @@
 package org.opennms.miniongateway.router;
 
+import java.util.List;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -36,8 +37,11 @@ public class MinionLookupServiceImpl implements MinionLookupService {
     }
 
     @Override
-    public Queue<UUID> findGatewayNodeWithLocation(String location) {
-        return minionByLocationCache.get(location);
+    public List<UUID> findGatewayNodeWithLocation(String location) {
+        // TODO consider different structure to retain node identifiers to avoid wrapping into list
+        // result must be indexed to support balancing of requests sent onto location (see Routing Task)
+        Queue<UUID> uuids = minionByLocationCache.get(location);
+        return uuids != null ? List.copyOf(uuids) : null;
     }
 
     @Override

--- a/minion-gateway/main/src/test/java/org/opennms/miniongateway/router/MinionLookupServiceImplTest.java
+++ b/minion-gateway/main/src/test/java/org/opennms/miniongateway/router/MinionLookupServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
@@ -99,7 +100,7 @@ public class MinionLookupServiceImplTest {
     public void findGatewayNodeWithLocation() {
         generateMinions(3);
 
-        Queue<UUID> uuids = minionLookupService.findGatewayNodeWithLocation("location");
+        List<UUID> uuids = minionLookupService.findGatewayNodeWithLocation("location");
         assertNotNull(uuids);
         assertEquals(3, uuids.size());
 

--- a/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
+++ b/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
@@ -309,7 +309,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     public CompletableFuture<RpcResponseProto> dispatch(String location, RpcRequestProto request) {
         StreamObserver<RpcRequestProto> rpcHandler = rpcConnectionTracker.lookupByLocationRoundRobin(location);
         if (rpcHandler == null) {
-            return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown location"));
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown location " + location));
         }
         return dispatch(rpcHandler, request);
     }
@@ -318,7 +318,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     public CompletableFuture<RpcResponseProto> dispatch(String location, String systemId, RpcRequestProto request) {
         StreamObserver<RpcRequestProto> rpcHandler = rpcConnectionTracker.lookupByMinionId(systemId);
         if (rpcHandler == null) {
-            return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown system id"));
+            return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown system id " + systemId));
         }
         return dispatch(rpcHandler, request);
     }


### PR DESCRIPTION
## Description
I brought back load balancing for requests directed at location. It is based on random rand robin, hoping that overall distribution will be fine over time.

Stacktrace we end with is not nicest one, but it does not have ignite core failure signs:
```
java.util.concurrent.CompletionException: org.apache.ignite.internal.client.thin.ClientServerError: Ignite failed to process request [7]: Failed to reduce job results due to undeclared user exception [task=org.opennms.miniongateway.grpc.server.tasks.EchoRoutingTask@6d7e9f85, err=class org.apache.ignite.IgniteException: Could not execute RPC request] (server status code [1])
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:331)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:346)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:632)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
	at org.apache.ignite.internal.client.thin.ClientComputeImpl.lambda$handleExecuteInitFuture$3d5fdfda$1(ClientComputeImpl.java:249)
	at org.apache.ignite.internal.util.future.GridFutureAdapter.notifyListener(GridFutureAdapter.java:399)
	at org.apache.ignite.internal.util.future.GridFutureAdapter.unblock(GridFutureAdapter.java:347)
	at org.apache.ignite.internal.util.future.GridFutureAdapter.unblockAll(GridFutureAdapter.java:335)
	at org.apache.ignite.internal.util.future.GridFutureAdapter.onDone(GridFutureAdapter.java:511)
	at org.apache.ignite.internal.util.future.GridFutureAdapter.onDone(GridFutureAdapter.java:490)
	at org.apache.ignite.internal.util.future.GridFutureAdapter.onDone(GridFutureAdapter.java:478)
	at org.apache.ignite.internal.client.thin.ClientComputeImpl$ClientComputeTask.acceptNotification(ClientComputeImpl.java:444)
	at org.apache.ignite.internal.client.thin.TcpClientChannel.lambda$processNextMessage$3(TcpClientChannel.java:485)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: org.apache.ignite.internal.client.thin.ClientServerError: Ignite failed to process request [7]: Failed to reduce job results due to undeclared user exception [task=org.opennms.miniongateway.grpc.server.tasks.EchoRoutingTask@6d7e9f85, err=class org.apache.ignite.IgniteException: Could not execute RPC request] (server status code [1])
	at org.apache.ignite.internal.client.thin.TcpClientChannel.processNextMessage(TcpClientChannel.java:449)
	at org.apache.ignite.internal.client.thin.TcpClientChannel.onMessage(TcpClientChannel.java:194)
	at org.apache.ignite.internal.client.thin.io.gridnioserver.GridNioClientConnection.onMessage(GridNioClientConnection.java:86)
	at org.apache.ignite.internal.client.thin.io.gridnioserver.GridNioClientListener.onMessage(GridNioClientListener.java:56)
	at org.apache.ignite.internal.client.thin.io.gridnioserver.GridNioClientListener.onMessage(GridNioClientListener.java:30)
	at org.apache.ignite.internal.util.nio.GridNioFilterChain$TailFilter.onMessageReceived(GridNioFilterChain.java:279)
	at org.apache.ignite.internal.util.nio.GridNioFilterAdapter.proceedMessageReceived(GridNioFilterAdapter.java:109)
	at org.apache.ignite.internal.util.nio.GridNioCodecFilter.onMessageReceived(GridNioCodecFilter.java:116)
	at org.apache.ignite.internal.util.nio.GridNioFilterAdapter.proceedMessageReceived(GridNioFilterAdapter.java:109)
	at org.apache.ignite.internal.util.nio.GridNioServer$HeadFilter.onMessageReceived(GridNioServer.java:3734)
	at org.apache.ignite.internal.util.nio.GridNioFilterChain.onMessageReceived(GridNioFilterChain.java:175)
	at org.apache.ignite.internal.util.nio.GridNioServer$ByteBufferNioClientWorker.processRead(GridNioServer.java:1211)
	at org.apache.ignite.internal.util.nio.GridNioServer$AbstractNioClientWorker.processSelectedKeysOptimized(GridNioServer.java:2508)
	at org.apache.ignite.internal.util.nio.GridNioServer$AbstractNioClientWorker.bodyInternal(GridNioServer.java:2273)
	at org.apache.ignite.internal.util.nio.GridNioServer$AbstractNioClientWorker.body(GridNioServer.java:1910)
	at org.apache.ignite.internal.util.worker.GridWorker.run(GridWorker.java:125)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
