### PR TITLE
HS-452: fixed the graphql playground target endpoint

### DIFF
--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: "http://{{ .Values.Prometheus.Server.ServiceName }}:{{ .Values.Prometheus.Server.Port }}/api/v1/query"
             - name: SPRING_WEBFLUX_BASE_PATH
               value: /api
+            - name: GRAPHQL_SPQR_GUI_TARGET_ENDPOINT
+              value: /api/graphql
           ports:
             - containerPort: {{ .Values.OpenNMS.API.Port }}
           {{- if not .Values.TestDeploy }}


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
start skaffold dev environment. Make sure the GraphQL playground is available at http://localhost:8123/api/gui without any error and the schema can be retrieved.

## Jira link(s)
- https://issues.opennms.org/browse/HS-452

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
