### PR TITLE
Add usage of Skaffold's --skip-tests flag to Minion build

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,7 +57,7 @@ build:
   - image: opennms/horizon-stream-minion
     context: minion
     custom:
-      buildCommand: "mvn install -Pbuild-docker-images-enabled -DskipTests -Ddocker.image=$IMAGE -Ddocker.skipPush={{ .PUSH_IMAGE | not }}"
+      buildCommand: "mvn install -Pbuild-docker-images-enabled -DskipTests=$SKIP_TEST -Ddocker.image=$IMAGE -Ddocker.skipPush={{ .PUSH_IMAGE | not }}"
       dependencies:
         paths: ["."]
         ignore: [


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- The new minion's tests will run even when skipping tests in Skaffold, this fixes it

## Jira link(s)
- https://issues.opennms.org/browse/HS-454

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
