### PR TITLE
HS-456: Updated protobuf version for arm chip

### DIFF
--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -75,7 +75,7 @@
         <pax.jdbc.version>1.5.2</pax.jdbc.version>
         <postgresql.version>42.3.2</postgresql.version>
         <prometheus.version>0.16.0</prometheus.version>
-        <protobuf.version>3.16.1</protobuf.version>   <!-- WARNING: this also controls the version of the protobuf compiler, change at your risk!-->
+        <protobuf.version>3.17.3</protobuf.version>   <!-- WARNING: this also controls the version of the protobuf compiler, change at your risk!-->
         <rate.limitted.logger.version>2.0.2</rate.limitted.logger.version>
         <rest-assured.version>4.3.3</rest-assured.version>
         <slf4j.version>1.7.33</slf4j.version>


### PR DESCRIPTION
## Description
Updating protobuf version from 3.16.1 to 3.17.3 in line with https://github.com/OpenNMS/horizon-stream/pull/361
Also this fixes the problem that occurs on M1 Mac machines

## Jira link(s)
- https://issues.opennms.org/browse/HS-456

## Flagged for review
n/a

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
