### PR TITLE
Fix minion KUBERNETES_SERVICE_NAME env var and port forwards

### DIFF
--- a/minion/assembly/src/main/resources/etc/org.opennms.core.ignite.client.cfg
+++ b/minion/assembly/src/main/resources/etc/org.opennms.core.ignite.client.cfg
@@ -1,4 +1,4 @@
 useKubernetes=${env:USE_KUBERNETES:-true}
-kubernetesServiceName=${env:KUBERNETES_SERVICE_NAME:-ignite-minion-gateway}
+kubernetes.service.name=${env:KUBERNETES_SERVICE_NAME:-ignite-minion-gateway}
 # Addresses are ignored when using Kubernetes
 addresses=${env:IGNITE_SERVER_ADDRESSES:-unknown}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -125,25 +125,21 @@ portForward:
     port: 5005 # Debug
     localPort: 11050
   - resourceType: deployment
-    resourceName: my-horizon-stream-minion
+    resourceName: opennms-minion
     port: 8181 # HTTP
     localPort: 12080
   - resourceType: deployment
-    resourceName: my-horizon-stream-minion
+    resourceName: opennms-minion
     port: 8102 # SSH
     localPort: 12022
   - resourceType: deployment
-    resourceName: my-horizon-stream-minion
+    resourceName: opennms-minion
     port: 5005 # Debug
     localPort: 12050
   - resourceType: deployment
     resourceName: onms-keycloak
     port: 8080 # HTTP
     localPort: 26080
-  - resourceType: deployment
-    resourceName: opennms-minion
-    port: 8201 # SSH
-    localPort: 27022
   - resourceType: deployment
     resourceName: mail-server
     port: 8025 # HTTP


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- This property was renamed in the blueprint file but not the cfg, and the env var stopped working
- Skaffold port forwards were pointing at the wrong name

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
