### PR TITLE
Make sure snmp value encoding is part of protobuf contract.

### DIFF
--- a/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-contract/src/main/proto/opennms/snmp/snmp.proto
+++ b/shared-lib/horizon-ipc/ipc-grpc/ipc-grpc-contract/src/main/proto/opennms/snmp/snmp.proto
@@ -62,7 +62,14 @@ enum SnmpValueType {
 
 message SnmpValue {
   SnmpValueType type = 1;
-  bytes value = 2;
+  oneof value {
+    sint32 sint32 = 2;
+    sint64 sint64 = 3;
+    uint32 uint32 = 4;
+    uint64 uint64 = 5;
+    string string = 6;
+    bytes bytes = 7;
+  };
 }
 
 enum Version {


### PR DESCRIPTION
## Description
I started to move away from `SnmpValue` byte representation which might soon be unavailable on core side.
This is a contract update which aligns snmp-rpc handler on minion end with snmp client on core side. Client still uses `SnmpValueFactory`, however it can be dropped or replaced with another structure which is independent of actual snmp library.
Marking this PR for now as draft to open discussion on how this part of communication could evolve.


## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
