### PR TITLE
Feature/fix cache config

### DIFF
--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/router/MinionLookupServiceImpl.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/router/MinionLookupServiceImpl.java
@@ -7,6 +7,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.Lock;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.CacheAtomicityMode;
+import org.apache.ignite.configuration.CacheConfiguration;
 import org.opennms.horizon.shared.ipc.grpc.server.manager.MinionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,8 +30,15 @@ public class MinionLookupServiceImpl implements MinionLookupService {
 
         this.ignite = ignite;
 
-        minionByIdCache = ignite.getOrCreateCache(MINIONS_BY_ID);
-        minionByLocationCache = ignite.getOrCreateCache(MINIONS_BY_LOCATION);
+        CacheConfiguration<String, UUID> minionByIdCacheConfig = new CacheConfiguration<String, UUID>().
+            setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL).
+            setName(MINIONS_BY_ID);
+        minionByIdCache = ignite.getOrCreateCache(minionByIdCacheConfig);
+
+        CacheConfiguration<String, Queue<UUID>> minionByLocationCacheConfig = new CacheConfiguration<String, Queue<UUID>>().
+            setAtomicityMode(CacheAtomicityMode.TRANSACTIONAL).
+            setName(MINIONS_BY_LOCATION);
+        minionByLocationCache = ignite.getOrCreateCache(minionByLocationCacheConfig);
     }
 
     @Override

--- a/minion-gateway/main/src/test/java/org/opennms/miniongateway/router/MinionLookupServiceImplTest.java
+++ b/minion-gateway/main/src/test/java/org/opennms/miniongateway/router/MinionLookupServiceImplTest.java
@@ -4,8 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -17,7 +19,9 @@ import java.util.concurrent.locks.Lock;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCluster;
+import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.configuration.CacheConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -74,15 +78,16 @@ public class MinionLookupServiceImplTest {
         doAnswer((Answer<Queue<UUID>>) invocationOnMock -> locationMap.put(invocationOnMock.getArgument(0), invocationOnMock.getArgument(1))).
             when(igniteLocationCache).put(any(), any());
 
-        when(ignite.getOrCreateCache(eq(MinionLookupServiceImpl.MINIONS_BY_ID))).thenReturn(igniteIdCache);
-        when(ignite.getOrCreateCache(eq(MinionLookupServiceImpl.MINIONS_BY_LOCATION))).thenReturn(igniteLocationCache);
+        doReturn(igniteIdCache).when(ignite).getOrCreateCache(argThat((CacheConfiguration config) -> config.getName().equals(MinionLookupServiceImpl.MINIONS_BY_ID)));
+        doReturn(igniteLocationCache).when(ignite).getOrCreateCache(argThat((CacheConfiguration config) -> config.getName().equals(MinionLookupServiceImpl.MINIONS_BY_LOCATION)));
+
         when(ignite.cache(eq(MinionLookupServiceImpl.MINIONS_BY_ID))).thenReturn(igniteIdCache);
-        when(ignite.cache(eq(MinionLookupServiceImpl.MINIONS_BY_ID))).thenReturn(igniteLocationCache);
+        when(ignite.cache(eq(MinionLookupServiceImpl.MINIONS_BY_LOCATION))).thenReturn(igniteLocationCache);
         when(ignite.cluster()).thenReturn(igniteCluster);
         when(igniteCluster.localNode()).thenReturn(clusterNode);
         when(clusterNode.id()).thenReturn(localNodeUUID);
 
-        
+
         minionLookupService = new MinionLookupServiceImpl(ignite);
     }
     


### PR DESCRIPTION
## Description
Initiate the ignite caches with a proper config to make them transactional. This will allow the caches to be locked for synchronizing.

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
