### PR TITLE
Add custom env vars plugin to inject new values into osgi configurations

### DIFF
--- a/minion/assembly/pom.xml
+++ b/minion/assembly/pom.xml
@@ -16,6 +16,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>osgi-config-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
             <version>${karaf.version}</version>
@@ -106,6 +112,9 @@
                     <startupFeatures>
                         <feature>eventadmin</feature>
                     </startupFeatures>
+                    <startupBundles>
+                        <bundle>mvn:org.opennms.horizon.shared/osgi-config-plugin/${project.version}</bundle>
+                    </startupBundles>
                     <bootFeatures>
                         <feature>wrap</feature>
                         <feature>shell</feature>

--- a/platform/assemblies/core-dynamic-dist/pom.xml
+++ b/platform/assemblies/core-dynamic-dist/pom.xml
@@ -28,6 +28,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>osgi-config-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.karaf.features</groupId>
             <artifactId>framework</artifactId>
             <type>kar</type>
@@ -98,6 +104,9 @@
                     <startupFeatures>
                         <feature>eventadmin</feature>
                     </startupFeatures>
+                    <startupBundles>
+                        <bundle>mvn:org.opennms.horizon.shared/osgi-config-plugin/${project.version}</bundle>
+                    </startupBundles>
                     <bootFeatures>
                         <feature>wrap</feature>
                         <feature>shell</feature>

--- a/shared-lib/osgi/osgi-config-plugin/pom.xml
+++ b/shared-lib/osgi/osgi-config-plugin/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms.horizon.shared</groupId>
+        <artifactId>osgi</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>osgi-config-plugin</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>OpenNMS Horizon :: Shared Library :: OSGi :: Config Plugin</name>
+    <description>Shallow copy of IPC api.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-Activator>org.opennms.horizon.shared.osgi.config.plugin.internal.Activator</Bundle-Activator>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/shared-lib/osgi/osgi-config-plugin/src/main/java/org/opennms/horizon/shared/osgi/config/plugin/internal/Activator.java
+++ b/shared-lib/osgi/osgi-config-plugin/src/main/java/org/opennms/horizon/shared/osgi/config/plugin/internal/Activator.java
@@ -1,0 +1,30 @@
+package org.opennms.horizon.shared.osgi.config.plugin.internal;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ConfigurationPlugin;
+
+public class Activator implements BundleActivator {
+
+    private ServiceRegistration<ConfigurationPlugin> registration;
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        EnvVarsConfigurationPlugin karafConfigurationPlugin = new EnvVarsConfigurationPlugin();
+        Dictionary<String, Object> serviceProps = new Hashtable<>();
+        serviceProps.put(ConfigurationPlugin.CM_RANKING, EnvVarsConfigurationPlugin.PLUGIN_RANKING);
+        serviceProps.put("config.plugin.id", EnvVarsConfigurationPlugin.PLUGIN_ID);
+        registration = context.registerService(ConfigurationPlugin.class, karafConfigurationPlugin, serviceProps);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        if (registration != null) {
+            registration.unregister();
+        }
+    }
+
+}

--- a/shared-lib/osgi/osgi-config-plugin/src/main/java/org/opennms/horizon/shared/osgi/config/plugin/internal/EnvVarsConfigurationPlugin.java
+++ b/shared-lib/osgi/osgi-config-plugin/src/main/java/org/opennms/horizon/shared/osgi/config/plugin/internal/EnvVarsConfigurationPlugin.java
@@ -1,0 +1,58 @@
+package org.opennms.horizon.shared.osgi.config.plugin.internal;
+
+import java.util.Dictionary;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.ConfigurationPlugin;
+
+/**
+ * Configuration plugin which attempts to map environment variables with configuration properties.
+ *
+ * Matching rules are environment variable of ORG_APACHE_KARAF_FEATURES_BOOT_FEATURE will fit:
+ * - pid org.apache.karaf.features, property boot.feature
+ * - pid org.apache.karaf, property features.boot.feature
+ *
+ * Properties are always lower case with dots as separator.
+ */
+public class EnvVarsConfigurationPlugin implements ConfigurationPlugin {
+
+    public static final int PLUGIN_RANKING = 510;
+    public static final String PLUGIN_ID = "org.opennms.horizon.shared.osgi.config.plugin";
+    private final Map<String, String> environment;
+
+    public EnvVarsConfigurationPlugin() {
+        this(System::getenv);
+    }
+
+    EnvVarsConfigurationPlugin(Supplier<Map<String, String>> environment) {
+        this.environment = environment.get();
+    }
+
+    @Override
+    public void modifyConfiguration(ServiceReference<?> reference, Dictionary<String, Object> properties) {
+        final Object pid = properties.get(Constants.SERVICE_PID);
+        if (pid == null) {
+            return;
+        }
+
+        String prefix = (pid.toString()).toUpperCase().replaceAll("\\.", "_");
+        Map<String, String> variables = environment;
+        for (String key : variables.keySet()) {
+            if (key.startsWith(prefix + "__")) {
+                // assume pid part is separated by _, so we strip one more character, then replace underscore with dots
+                // to construct desired key
+                String property = key.substring(prefix.length() + 2)
+                    .replaceAll("_", ".").toLowerCase();
+
+                String value = variables.get(key);
+                if (value != null) {
+                    properties.put(property, value.trim());
+                }
+            }
+        }
+
+    }
+
+}

--- a/shared-lib/osgi/osgi-config-plugin/src/test/java/org/opennms/horizon/shared/osgi/config/plugin/internal/EnvVarsConfigurationPluginTest.java
+++ b/shared-lib/osgi/osgi-config-plugin/src/test/java/org/opennms/horizon/shared/osgi/config/plugin/internal/EnvVarsConfigurationPluginTest.java
@@ -1,0 +1,39 @@
+package org.opennms.horizon.shared.osgi.config.plugin.internal;
+
+import static org.junit.Assert.*;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EnvVarsConfigurationPluginTest {
+
+    @Mock
+    ServiceReference serviceReference;
+
+    @Test
+    public void checkBasicLookup() {
+        Dictionary<String, Object> properties = new Hashtable<>();
+        properties.put(Constants.SERVICE_PID, "a.b");
+        EnvVarsConfigurationPlugin envVarsConfigurationPlugin = new EnvVarsConfigurationPlugin(() -> Map.of("A_B__C", "10.0"));
+        envVarsConfigurationPlugin.modifyConfiguration(
+            serviceReference, properties
+        );
+        assertEquals("10.0", properties.get("c"));
+
+        properties = new Hashtable<>();
+        properties.put(Constants.SERVICE_PID, "a");
+        envVarsConfigurationPlugin.modifyConfiguration(
+            serviceReference, properties
+        );
+        assertNull(properties.get("c"));
+    }
+
+}

--- a/shared-lib/osgi/pom.xml
+++ b/shared-lib/osgi/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.opennms.horizon.shared</groupId>
+        <artifactId>shared-lib</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>osgi</artifactId>
+    <name>OpenNMS Horizon :: Shared Library :: OSGi</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>osgi-config-plugin</module>
+    </modules>
+
+</project>

--- a/shared-lib/pom.xml
+++ b/shared-lib/pom.xml
@@ -26,7 +26,8 @@
         <module>icmp-api</module>
         <module>protobuf</module>
         <module>task-set-service</module>
-      <module>ignite-tasks</module>
+        <module>ignite-tasks</module>
+        <module>osgi</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Description
Default plugin from Karaf can override only existing properties, while this one can inject new values. Properties are guessed from remaining part of env variable after stripping PID part from it.

PR ships it for both - core and minion through bootstrap bundle which should be activated earlier than boot features.

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
