### PR TITLE
[HS-497] Disable deployment status checking in Skaffold by default

### DIFF
--- a/operator/skaffold.yaml
+++ b/operator/skaffold.yaml
@@ -18,6 +18,7 @@ profiles:
               dockerfile:
                 path: Dockerfile
     deploy:
+      statusCheck: false
       helm:
         releases:
           - name: opennms-operator

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -184,6 +184,7 @@ portForward:
     port: 5005 #debug
     localPort: 28050
 deploy:
+  statusCheck: false
   helm:
     releases:
       - name: opennms
@@ -204,6 +205,7 @@ profiles:
   - name: prod
   - name: use-operator
     deploy:
+      statusCheck: false
       kubectl:
         manifests:
           - skaffold-custom-resource.yaml


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- This status check was causing skaffold to exit in the event of a deployment failure, which cleaned up the cluster, and made troubleshooting impossible
- As a bonus, dev loop and pod log streaming will start immediately
- Downside, will throw errors during initial port forwards

## Jira link(s)
- https://issues.opennms.org/browse/HS-497

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->
- Need someone to test this out before I merge and make sure it won't cause any issues
- Port forwarding in particular could be a problem with this change. Skaffold should eventually forward those ports, but it has always been flaky.

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
