### PR TITLE
bind on port 8080 (instead of 80) to allow container to run unprivileged

### DIFF
--- a/charts/opennms/values.yaml
+++ b/charts/opennms/values.yaml
@@ -51,7 +51,7 @@ OpenNMS:
     Image: opennms/horizon-stream-ui
     ImagePullPolicy: IfNotPresent
     Replicas: 1
-    Port: 80
+    Port: 8080
     Resources:
       Limits:
         Cpu: "1"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,9 +17,9 @@ COPY --link . ./
 # Starts Vite dev server, used by Skaffold
 FROM sources as development
 
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["yarn", "run", "dev"]
-CMD ["--port", "80"]
+CMD ["--port", "8080"]
 
 # Builds the app for production
 FROM sources as build
@@ -40,5 +40,5 @@ COPY --link /nginx /etc/nginx
 # Copy prod files from prod-build stage
 COPY --from=build --link /app/dist /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 8080
 ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/ui/nginx/conf.d/default.conf
+++ b/ui/nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen      80;
+    listen      8080;
     server_name horizon-stream-ui;
 
     # Vue.js app

--- a/ui/nginx/nginx.conf
+++ b/ui/nginx/nginx.conf
@@ -1,10 +1,9 @@
 # This is a copy of the default nginx.conf from the 1.23.1-alpine image
 
-user  nginx;
 worker_processes  auto;
 
 error_log  /var/log/nginx/error.log notice;
-pid        /var/run/nginx.pid;
+pid        /tmp/nginx.pid;
 
 
 events {


### PR DESCRIPTION
run the UI container on port 8080 instead of 80 to allow it to run without special privileges