### PR TITLE
remove setcap calls from binaries to allow them to run without special privs

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,8 +8,7 @@ ENV GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS="opennms-helm-app"
 
 USER root
 
-RUN apk add --update --no-cache libcap && \
- setcap 'cap_net_bind_service=+ep' /usr/share/grafana/bin/grafana-server
+RUN apk add --update --no-cache libcap
 
 ARG GF_GID="0"
 ARG GF_INSTALL_IMAGE_RENDERER_PLUGIN="false"

--- a/platform/assemblies/docker/src/main/docker/core/Dockerfile
+++ b/platform/assemblies/docker/src/main/docker/core/Dockerfile
@@ -33,12 +33,6 @@ FROM ${BASE_IMAGE}
 RUN groupadd --gid 10001 horizon-stream && \
     useradd --system --uid 10001 --gid horizon-stream horizon-stream --home-dir /opt/horizon-stream
 
-# https://issues.opennms.org/browse/NMS-12635
-# It is possible to set sysctls: net.ipv4.ping_group_range=0 10001 which allows the container using sockets. If we run on
-# infrastructure which doesn't allow whitelisting net.ipv4.ping_group_range as a safe sysctl (Kubernetes < 1.18) the
-# minimal solution is giving the Java binary the cap_net_raw+ep capabilities.
-RUN setcap cap_net_raw+ep $(readlink -f /usr/bin/java)
-
 # Install entrypoint wrapper and health check script
 COPY container-fs/entrypoint.sh /
 COPY container-fs/health.sh /


### PR DESCRIPTION
remove a few unneeded setcap calls

this allows us to get closer to running the chart on OpenShift:
```
% kubectl get pods
NAME                                         READY   STATUS             RESTARTS   AGE
grafana-545fd46ffd-ggpbd                     1/1     Running            0          5m6s
mail-server-79f5bc7648-47r76                 1/1     Running            2          12h
onms-kafka-7988b454-vf2tg                    1/1     Running            2          12h
onms-keycloak-6fb84844cf-w77bs               1/1     Running            2          12h
opennms-core-66f9cf5cb4-tbxf9                1/1     Running            2          12h
opennms-inventory-84675fd5c5-559k7           0/1     ImagePullBackOff   0          12h
opennms-metrics-processor-84d5556c48-gcc52   0/1     ImagePullBackOff   0          12h
opennms-minion-gateway-85b4db9bf8-778pl      1/1     Running            2          12h
opennms-nginx-errors-7fc4584f5-ptlch         1/1     Running            2          12h
opennms-notifications-56cc9f6648-6m7d6       1/1     Running            5          12h
opennms-rest-server-6dfdfc467-f4brm          1/1     Running            2          12h
opennms-ui-67c4c7c4f6-66wlg                  1/1     Running            2          12h
postgres-68d5847cb5-h7r8g                    1/1     Running            2          12h
prometheus-cfc9c79df-crqsr                   1/1     Running            2          12h
prometheus-pushgateway-7666dc98fc-s5t6c      1/1     Running            2          12h
```