### PR TITLE
HS-493: Add TrapConfig handling with Twin/TaskSets

### DIFF
--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalServiceFactoryImpl.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskExecutorLocalServiceFactoryImpl.java
@@ -1,5 +1,6 @@
 package org.opennms.horizon.minion.taskset.worker.impl;
 
+import org.opennms.horizon.minion.plugin.api.registries.ListenerFactoryRegistry;
 import org.opennms.horizon.minion.plugin.api.registries.MonitorRegistry;
 import org.opennms.horizon.minion.taskset.worker.TaskExecutionResultProcessor;
 import org.opennms.horizon.minion.taskset.worker.TaskExecutorLocalService;
@@ -17,6 +18,7 @@ public class TaskExecutorLocalServiceFactoryImpl implements TaskExecutorLocalSer
 
     private final OpennmsScheduler scheduler;
     private final TaskExecutionResultProcessor resultProcessor;
+    private final ListenerFactoryRegistry listenerFactoryRegistry;
 
 //========================================
 // Constructor
@@ -24,11 +26,13 @@ public class TaskExecutorLocalServiceFactoryImpl implements TaskExecutorLocalSer
 
     public TaskExecutorLocalServiceFactoryImpl(
         OpennmsScheduler scheduler,
-        TaskExecutionResultProcessor resultProcessor
+        TaskExecutionResultProcessor resultProcessor,
+        ListenerFactoryRegistry listenerFactoryRegistry
     ) {
 
         this.scheduler = scheduler;
         this.resultProcessor = resultProcessor;
+        this.listenerFactoryRegistry = listenerFactoryRegistry;
     }
 
 //========================================
@@ -42,7 +46,7 @@ public class TaskExecutorLocalServiceFactoryImpl implements TaskExecutorLocalSer
                 return new TaskExecutorLocalMonitorServiceImpl(scheduler, taskDefinition, resultProcessor, monitorRegistry);
 
             case LISTENER:
-                TaskListenerRetryable listenerService = new TaskListenerRetryable(taskDefinition, resultProcessor);
+                TaskListenerRetryable listenerService = new TaskListenerRetryable(taskDefinition, resultProcessor, listenerFactoryRegistry);
                 return new TaskCommonRetryExecutor(scheduler, taskDefinition, resultProcessor, listenerService);
 
             case CONNECTOR:

--- a/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskListenerRetryable.java
+++ b/minion/minion-taskset/taskset-worker/src/main/java/org/opennms/horizon/minion/taskset/worker/impl/TaskListenerRetryable.java
@@ -23,7 +23,7 @@ public class TaskListenerRetryable implements RetryableExecutor {
     private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(TaskListenerRetryable.class);
 
     @SpringResource(resourceClass = ListenerFactoryRegistry.class)
-    private transient ListenerFactoryRegistry listenerFactoryRegistry;
+    private ListenerFactoryRegistry listenerFactoryRegistry;
 
     private Logger log = DEFAULT_LOGGER;
 
@@ -33,9 +33,12 @@ public class TaskListenerRetryable implements RetryableExecutor {
 
     private Runnable onDisconnect;
 
-    public TaskListenerRetryable(TaskDefinition taskDefinition, TaskExecutionResultProcessor resultProcessor) {
+    public TaskListenerRetryable(TaskDefinition taskDefinition,
+                                 TaskExecutionResultProcessor resultProcessor,
+                                 ListenerFactoryRegistry listenerFactoryRegistry) {
         this.taskDefinition = taskDefinition;
         this.resultProcessor = resultProcessor;
+        this.listenerFactoryRegistry = listenerFactoryRegistry;
     }
 
 //========================================

--- a/minion/minion-taskset/taskset-worker/src/main/resources/OSGI-INF/blueprint/horizon-ignite.xml
+++ b/minion/minion-taskset/taskset-worker/src/main/resources/OSGI-INF/blueprint/horizon-ignite.xml
@@ -62,6 +62,7 @@
   <bean id="workflowExecutorLocalServiceFactory" class="org.opennms.horizon.minion.taskset.worker.impl.TaskExecutorLocalServiceFactoryImpl">
     <argument ref="opennmsScheduler"/>
     <argument ref="workflowExecutionResultProcessor"/>
+    <argument ref="listenerFactoryRegistry"/>
   </bean>
 
   <bean id="workflowLifecycleManager" class="org.opennms.horizon.minion.taskset.worker.impl.TaskSetLifecycleManagerImpl" destroy-method="close">

--- a/minion/minion-traps/features/pom.xml
+++ b/minion/minion-traps/features/pom.xml
@@ -55,6 +55,13 @@
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.minion</groupId>
+            <artifactId>plugin-features</artifactId>
+            <version>${project.version}</version>
+            <classifier>features</classifier>
+            <type>xml</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,6 +86,7 @@
                                 <descriptor>mvn:org.opennms.horizon.minion/ipc-features/${project.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.opennms.horizon.minion/grpc-features/${project.version}/xml/features</descriptor>
                                 <descriptor>mvn:org.opennms.horizon.minion/observability-features/${project.version}/xml/features</descriptor>
+                                <descriptor>mvn:org.opennms.horizon.minion/plugin-features/${project.version}/xml/features</descriptor>
                                 <descriptor>file:${project.build.directory}/feature/feature.xml</descriptor>
                             </descriptors>
                             <javase>11</javase>

--- a/minion/minion-traps/features/src/main/feature/feature.xml
+++ b/minion/minion-traps/features/src/main/feature/feature.xml
@@ -4,6 +4,7 @@
     <feature name="minion-traps" version="${project.version}">
         <feature>ipc-minion</feature>
         <feature>snmp-snmp4j</feature>
+        <feature>plugins-api</feature>
         <bundle>mvn:org.opennms.horizon.minion/traps-listener/${project.version}</bundle>
     </feature>
 

--- a/minion/minion-traps/listener/pom.xml
+++ b/minion/minion-traps/listener/pom.xml
@@ -34,5 +34,10 @@
             <artifactId>snmp-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.minion</groupId>
+            <artifactId>plugins-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapListener.java
+++ b/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapListener.java
@@ -48,7 +48,7 @@ import org.opennms.horizon.shared.snmp.traps.TrapdInstrumentation;
 import org.opennms.horizon.shared.utils.InetAddressUtils;
 import org.opennms.horizon.snmp.api.SnmpResult;
 import org.opennms.horizon.snmp.api.SnmpValue;
-import org.opennms.sink.traps.contract.TrapsBaseConfig;
+import org.opennms.sink.traps.contract.TrapConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.snmp4j.PDU;
@@ -73,13 +73,13 @@ public class TrapListener implements TrapNotificationListener, Listener {
 
     private final AtomicBoolean registeredForTraps = new AtomicBoolean(false);
 
-    private final TrapsBaseConfig trapsBaseConfig;
+    private final TrapConfig trapsBaseConfig;
 
     private final SnmpHelper snmpHelper;
 
     public static final TrapdInstrumentation trapdInstrumentation = new TrapdInstrumentation();
 
-    public TrapListener(TrapsBaseConfig trapsBaseConfig,
+    public TrapListener(TrapConfig trapsBaseConfig,
                         MessageDispatcherFactory messageDispatcherFactory,
                         IpcIdentity identity,
                         SnmpHelper snmpHelper) {
@@ -174,7 +174,7 @@ public class TrapListener implements TrapNotificationListener, Listener {
     }
 
 
-    private InetAddress getInetAddress(TrapsBaseConfig trapsBaseConfig) {
+    private InetAddress getInetAddress(TrapConfig trapsBaseConfig) {
         if (trapsBaseConfig.getSnmpTrapAddress().equals("*")) {
             return null;
         }

--- a/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapListenerFactory.java
+++ b/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapListenerFactory.java
@@ -36,8 +36,7 @@ import org.opennms.horizon.minion.plugin.api.ServiceMonitorResponse;
 import org.opennms.horizon.shared.ipc.rpc.IpcIdentity;
 import org.opennms.horizon.shared.ipc.sink.api.MessageDispatcherFactory;
 import org.opennms.horizon.shared.snmp.SnmpHelper;
-import org.opennms.sink.traps.contract.TrapsBaseConfig;
-import org.opennms.sink.traps.contract.TrapsConfig;
+import org.opennms.sink.traps.contract.TrapConfig;
 
 import java.util.function.Consumer;
 
@@ -57,14 +56,12 @@ public class TrapListenerFactory implements ListenerFactory {
 
     @Override
     public Listener create(Consumer<ServiceMonitorResponse> resultProcessor, Any config) {
-        if (!config.is(TrapsConfig.class)) {
+        if (!config.is(TrapConfig.class)) {
             throw new IllegalArgumentException("configuration must be TrapsConfig; type-url=" + config.getTypeUrl());
         }
 
         try {
-            TrapsConfig trapsConfig = config.unpack(TrapsConfig.class);
-            // TODO : Ideally we will get one TrapsBaseConfig from Minion Gateway.
-            TrapsBaseConfig trapsBaseConfig = trapsConfig.getTrapsBaseConfig(0);
+            TrapConfig trapsBaseConfig = config.unpack(TrapConfig.class);
             return new TrapListener(trapsBaseConfig, messageDispatcherFactory, identity, snmpHelper);
         } catch (InvalidProtocolBufferException e) {
             throw new IllegalArgumentException("Error while parsing config with type-url=" + config.getTypeUrl());

--- a/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapListenerFactory.java
+++ b/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapListenerFactory.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.minion.traps.listener;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.opennms.horizon.minion.plugin.api.Listener;
+import org.opennms.horizon.minion.plugin.api.ListenerFactory;
+import org.opennms.horizon.minion.plugin.api.ServiceMonitorResponse;
+import org.opennms.horizon.shared.ipc.rpc.IpcIdentity;
+import org.opennms.horizon.shared.ipc.sink.api.MessageDispatcherFactory;
+import org.opennms.horizon.shared.snmp.SnmpHelper;
+import org.opennms.sink.traps.contract.TrapsBaseConfig;
+import org.opennms.sink.traps.contract.TrapsConfig;
+
+import java.util.function.Consumer;
+
+public class TrapListenerFactory implements ListenerFactory {
+
+    private final MessageDispatcherFactory messageDispatcherFactory;
+
+    private final IpcIdentity identity;
+
+    private final SnmpHelper snmpHelper;
+
+    public TrapListenerFactory(MessageDispatcherFactory messageDispatcherFactory, IpcIdentity identity, SnmpHelper snmpHelper) {
+        this.messageDispatcherFactory = messageDispatcherFactory;
+        this.identity = identity;
+        this.snmpHelper = snmpHelper;
+    }
+
+    @Override
+    public Listener create(Consumer<ServiceMonitorResponse> resultProcessor, Any config) {
+        if (!config.is(TrapsConfig.class)) {
+            throw new IllegalArgumentException("configuration must be TrapsConfig; type-url=" + config.getTypeUrl());
+        }
+
+        try {
+            TrapsConfig trapsConfig = config.unpack(TrapsConfig.class);
+            // TODO : Ideally we will get one TrapsBaseConfig from Minion Gateway.
+            TrapsBaseConfig trapsBaseConfig = trapsConfig.getTrapsBaseConfig(0);
+            return new TrapListener(trapsBaseConfig, messageDispatcherFactory, identity, snmpHelper);
+        } catch (InvalidProtocolBufferException e) {
+            throw new IllegalArgumentException("Error while parsing config with type-url=" + config.getTypeUrl());
+        }
+
+    }
+
+}

--- a/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapSinkModule.java
+++ b/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapSinkModule.java
@@ -37,14 +37,15 @@ import org.opennms.horizon.shared.ipc.sink.api.AggregationPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.AsyncPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.SinkModule;
 import org.opennms.horizon.shared.snmp.traps.TrapdConfig;
+import org.opennms.sink.traps.contract.TrapsBaseConfig;
 
 public class TrapSinkModule implements SinkModule<TrapDTO, TrapLogDTO> {
 
-    private final TrapdConfig config;
-
     private final IpcIdentity identity;
 
-    public TrapSinkModule(TrapdConfig trapdConfig, IpcIdentity identity) {
+    private final TrapsBaseConfig config;
+
+    public TrapSinkModule(TrapsBaseConfig trapdConfig, IpcIdentity identity) {
         this.config = trapdConfig;
         this.identity = identity;
     }
@@ -56,7 +57,7 @@ public class TrapSinkModule implements SinkModule<TrapDTO, TrapLogDTO> {
 
     @Override
     public int getNumConsumerThreads() {
-        return config.getNumThreads();
+        return config.getListenerConfig().getNumThreads();
     }
 
     @Override
@@ -92,12 +93,12 @@ public class TrapSinkModule implements SinkModule<TrapDTO, TrapLogDTO> {
         return new AggregationPolicy<>() {
             @Override
             public int getCompletionSize() {
-                return config.getBatchSize();
+                return config.getListenerConfig().getBatchSize();
             }
 
             @Override
             public int getCompletionIntervalMs() {
-                return config.getBatchIntervalMs();
+                return config.getListenerConfig().getBatchIntervalMs();
             }
 
             @Override
@@ -130,12 +131,12 @@ public class TrapSinkModule implements SinkModule<TrapDTO, TrapLogDTO> {
         return new AsyncPolicy() {
             @Override
             public int getQueueSize() {
-                return config.getQueueSize();
+                return config.getListenerConfig().getQueueSize();
             }
 
             @Override
             public int getNumThreads() {
-                return config.getNumThreads();
+                return config.getListenerConfig().getNumThreads();
             }
 
             @Override

--- a/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapSinkModule.java
+++ b/minion/minion-traps/listener/src/main/java/org/opennms/horizon/minion/traps/listener/TrapSinkModule.java
@@ -36,16 +36,15 @@ import org.opennms.horizon.shared.ipc.rpc.IpcIdentity;
 import org.opennms.horizon.shared.ipc.sink.api.AggregationPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.AsyncPolicy;
 import org.opennms.horizon.shared.ipc.sink.api.SinkModule;
-import org.opennms.horizon.shared.snmp.traps.TrapdConfig;
-import org.opennms.sink.traps.contract.TrapsBaseConfig;
+import org.opennms.sink.traps.contract.TrapConfig;
 
 public class TrapSinkModule implements SinkModule<TrapDTO, TrapLogDTO> {
 
     private final IpcIdentity identity;
 
-    private final TrapsBaseConfig config;
+    private final TrapConfig config;
 
-    public TrapSinkModule(TrapsBaseConfig trapdConfig, IpcIdentity identity) {
+    public TrapSinkModule(TrapConfig trapdConfig, IpcIdentity identity) {
         this.config = trapdConfig;
         this.identity = identity;
     }

--- a/minion/minion-traps/listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/minion/minion-traps/listener/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,53 +1,24 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0"
            xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
-        https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
-        http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.3.0
-        http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.3.0.xsd">
+        https://osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
 
-      <!--Keeping the persistent id same as classic minion-->
-    <cm:property-placeholder id="trapHandlerDefaultProperties" persistent-id="org.opennms.netmgt.trapd" update-strategy="reload">
-        <cm:default-properties>
-            <cm:property name="trapd.listen.interface" value="0.0.0.0" /> <!-- the interface the TrapListener listens for traps -->
-            <cm:property name="trapd.listen.port" value="1162" /> <!-- the port the TrapListener listens for traps -->
-            <cm:property name="trapd.includeRawMessage" value="false" />
-          <!--    TODO : Should these be part of Minion Gateway now ?-->
-            <cm:property name="trapd.threads" value="0"/> <!-- the number of threads for the producer -->
-            <cm:property name="trapd.queue.size" value="10000" />
-            <cm:property name="trapd.batch.size" value="1000" />
-            <cm:property name="trapd.batch.interval" value="500" />
-        </cm:default-properties>
-    </cm:property-placeholder>
-
-    <bean id="trapdConfig" class="org.opennms.horizon.shared.snmp.traps.TrapdConfigBean">
-        <property name="snmpTrapPort" value="${trapd.listen.port}"/>
-        <property name="snmpTrapAddress" value="${trapd.listen.interface}"/>
-        <property name="numThreads" value="${trapd.threads}" />
-        <property name="queueSize" value="${trapd.queue.size}" />
-        <property name="batchSize" value="${trapd.batch.size}" />
-        <property name="batchIntervalMs" value="${trapd.batch.interval}" />
-        <property name="includeRawMessage" value="${trapd.includeRawMessage}"/>
-    </bean>
-
-    <service ref="trapdConfig" interface="org.opennms.horizon.shared.snmp.traps.TrapdConfig"/>
 
     <reference id="snmpHelper" interface="org.opennms.horizon.shared.snmp.SnmpHelper"/>
     <reference id="messageDispatcherFactory" interface="org.opennms.horizon.shared.ipc.sink.api.MessageDispatcherFactory"/>
     <reference id="identity" interface="org.opennms.horizon.shared.ipc.rpc.IpcIdentity"/>
 
-    <bean id="trapListener" class="org.opennms.horizon.minion.traps.listener.TrapListener" init-method="start" destroy-method="stop">
-        <argument ref="trapdConfig"/>
-        <argument ref="snmpHelper"/>
+
+    <bean id="trapListenerFactory" class="org.opennms.horizon.minion.traps.listener.TrapListenerFactory">
         <argument ref="messageDispatcherFactory"/>
         <argument ref="identity"/>
+        <argument ref="snmpHelper"/>
     </bean>
 
-    <service ref="trapListener" interface="org.opennms.horizon.minion.ipc.twin.api.TwinListener">
+    <service ref="trapListenerFactory" interface="org.opennms.horizon.minion.plugin.api.ListenerFactory">
         <service-properties>
-            <entry key="message.listener.topic" value="trapd.listener.config" />
+            <entry key="listener.name" value="trapd.listener.config"/>
         </service-properties>
     </service>
-
 
 </blueprint>

--- a/platform/assemblies/features/src/main/feature/feature.xml
+++ b/platform/assemblies/features/src/main/feature/feature.xml
@@ -631,6 +631,10 @@
         <feature>horizon-grpc-contract</feature>
         <feature>snmp-snmp4j</feature>
         <feature>horizon-grpc</feature>
+        <feature>horizon-ignite</feature>
+        <feature>horizon-shared-lang</feature>
+        <feature>horizon-shared-task-set-service</feature>
+        <feature>horizon-shared-task-set-publisher</feature>
         <bundle>mvn:org.opennms.horizon.shared/ipc-api/${project.version}</bundle>
         <bundle dependency="true">mvn:org.opennms.horizon.shared/horizon-common-logging/${project.version}</bundle>
         <bundle>mvn:org.opennms.horizon/traps/${project.version}</bundle>

--- a/platform/traps/pom.xml
+++ b/platform/traps/pom.xml
@@ -93,6 +93,11 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-protobuf</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.opennms.horizon.shared</groupId>
+            <artifactId>task-set-ignite-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>

--- a/platform/traps/src/main/java/org/opennms/horizon/traps/consumer/TrapSinkConsumer.java
+++ b/platform/traps/src/main/java/org/opennms/horizon/traps/consumer/TrapSinkConsumer.java
@@ -129,10 +129,8 @@ public class TrapSinkConsumer implements  EventListener, Processor {
     public void init() throws Exception {
         eventSubscriptionService.addEventListener(this, EventConstants.CONFIG_UPDATED_UEI);
         eventCreator = new EventCreator(interfaceToNodeCache, eventConfDao, snmpHelper);
-        registerTwinPublisher();
         // Initialize Config.
         initializeConfig();
-        //messageConsumerManager.registerConsumer(this);
     }
 
     void initializeConfig() throws IOException {
@@ -154,25 +152,9 @@ public class TrapSinkConsumer implements  EventListener, Processor {
         publishTrapConfig();
     }
 
-    private void registerTwinPublisher() {
-        // Register Twin Publisher
-        try {
-            twinSession = twinPublisher.register(TrapListenerConfig.TWIN_KEY, TrapListenerConfig.class, null);
-        } catch (IOException e) {
-            LOG.error("Failed to register twin for trap listener config", e);
-            throw new RuntimeException(e);
-        }
-    }
+
 
     private void publishTrapConfig() {
-       /* // Publish existing config.
-        try {
-            twinSession.publish(from(config));
-            LOG.info("Published Trap config with Twin Publisher");
-        } catch (IOException e) {
-            LOG.error("Failed to publish trap listener config", e);
-            throw new RuntimeException(e);
-        }*/
 
         TaskSet trapsConfigTaskSet = TaskSet.newBuilder()
             .addTaskDefinition(TaskDefinition.newBuilder()

--- a/platform/traps/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/traps/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -34,6 +34,13 @@
     <reference id="sessionUtils" interface="org.opennms.horizon.db.dao.api.SessionUtils" />
     <reference id="eventSubscriptionService" interface="org.opennms.horizon.events.api.EventSubscriptionService" availability="mandatory"/>
     <reference id="snmpHelper" interface="org.opennms.horizon.shared.snmp.SnmpHelper" />
+    <reference id="igniteClient" interface="org.apache.ignite.client.IgniteClient"/>
+    <reference id="igniteTaskSetClientFactory" interface="org.opennms.taskset.service.igniteclient.TaskSetIgnitePublisherFactory"/>
+
+    <bean id="taskSetIgniteClient" factory-ref="igniteTaskSetClientFactory" factory-method="create">
+        <argument ref="igniteClient"/>
+    </bean>
+
     <bean id="trapSinkConsumer" class="org.opennms.horizon.traps.consumer.TrapSinkConsumer"
           init-method="init">
         <property name="eventConfDao" ref="eventConfDao"/>
@@ -45,6 +52,7 @@
         <property name="sessionUtils" ref="sessionUtils"/>
         <property name="eventSubscriptionService" ref="eventSubscriptionService"/>
         <property name="snmpHelper" ref="snmpHelper"/>
+        <property name="taskSetPublisher" ref="taskSetIgniteClient"/>
     </bean>
 
     <camelContext autoStartup="true" id="trapConsumerCamelContext" xmlns="http://camel.apache.org/schema/blueprint"

--- a/platform/traps/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/platform/traps/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -48,7 +48,6 @@
         <property name="distPollerDao" ref="distPollerDao"/>
         <property name="interfaceToNodeCache" ref="interfaceToNodeCache"/>
         <property name="configService" ref="configService"/>
-        <property name="twinPublisher" ref="twinPublisher"/>
         <property name="sessionUtils" ref="sessionUtils"/>
         <property name="eventSubscriptionService" ref="eventSubscriptionService"/>
         <property name="snmpHelper" ref="snmpHelper"/>

--- a/platform/traps/src/main/resources/trapd-config.json
+++ b/platform/traps/src/main/resources/trapd-config.json
@@ -1,6 +1,6 @@
 {
   "snmpTrapAddress":"*",
-  "snmpTrapPort":10162,
+  "snmpTrapPort":1162,
   "newSuspectOnTrap":false,
   "snmpV3Users":[],
   "includeRawMessage":false,

--- a/platform/traps/src/test/java/org/opennms/horizon/traps/consumer/TrapdConfigJsonTest.java
+++ b/platform/traps/src/test/java/org/opennms/horizon/traps/consumer/TrapdConfigJsonTest.java
@@ -35,7 +35,6 @@ import org.mockito.Mockito;
 import org.opennms.core.ipc.twin.api.TwinPublisher;
 import org.opennms.horizon.config.service.api.ConfigConstants;
 import org.opennms.horizon.config.service.api.ConfigService;
-import org.opennms.horizon.shared.snmp.traps.TrapListenerConfig;
 import org.opennms.horizon.shared.snmp.traps.TrapdConfigBean;
 import org.opennms.taskset.contract.TaskSet;
 import org.opennms.taskset.service.api.TaskSetPublisher;
@@ -53,7 +52,6 @@ public class TrapdConfigJsonTest {
         TrapSinkConsumer trapSinkConsumer = new TrapSinkConsumer();
         ConfigService configService = new MockConfigService();
         TwinPublisher twinPublisher = Mockito.mock(TwinPublisher.class);
-        trapSinkConsumer.setTwinPublisher(twinPublisher);
         trapSinkConsumer.setConfigService(configService);
         trapSinkConsumer.setTaskSetPublisher(new TaskSetPublisher() {
             @Override

--- a/platform/traps/src/test/java/org/opennms/horizon/traps/consumer/TrapdConfigJsonTest.java
+++ b/platform/traps/src/test/java/org/opennms/horizon/traps/consumer/TrapdConfigJsonTest.java
@@ -37,6 +37,8 @@ import org.opennms.horizon.config.service.api.ConfigConstants;
 import org.opennms.horizon.config.service.api.ConfigService;
 import org.opennms.horizon.shared.snmp.traps.TrapListenerConfig;
 import org.opennms.horizon.shared.snmp.traps.TrapdConfigBean;
+import org.opennms.taskset.contract.TaskSet;
+import org.opennms.taskset.service.api.TaskSetPublisher;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -53,15 +55,10 @@ public class TrapdConfigJsonTest {
         TwinPublisher twinPublisher = Mockito.mock(TwinPublisher.class);
         trapSinkConsumer.setTwinPublisher(twinPublisher);
         trapSinkConsumer.setConfigService(configService);
-        trapSinkConsumer.setTwinSession(new TwinPublisher.Session<TrapListenerConfig>() {
+        trapSinkConsumer.setTaskSetPublisher(new TaskSetPublisher() {
             @Override
-            public void publish(TrapListenerConfig obj) throws IOException {
+            public void publishTaskSet(String location, TaskSet taskSet) {
                 //Ignore
-            }
-
-            @Override
-            public void close() throws IOException {
-
             }
         });
         trapSinkConsumer.initializeConfig();

--- a/shared-lib/protobuf/src/main/proto/traps-config.proto
+++ b/shared-lib/protobuf/src/main/proto/traps-config.proto
@@ -33,20 +33,14 @@ package opennms.sink.traps;
 option java_multiple_files = true;
 option java_package = "org.opennms.sink.traps.contract";
 
-message TrapsBaseConfig {
+message TrapConfig {
   string snmp_trap_address = 1;
   int32 snmp_trap_port = 2;
   bool new_suspect_on_trap = 3;
   bool include_raw_message = 4;
   bool use_address_from_varbind = 5;
-  // Config specific to a location
-  // If not specified, config applies to all locations
-  optional string location = 6;
-  // Config specific to minion
-  // If not specified, config applies to all minions
-  optional string system_id = 7;
-  repeated SnmpV3User snmp_v3_user = 8;
-  ListenerConfig listener_config = 9;
+  repeated SnmpV3User snmp_v3_user = 6;
+  ListenerConfig listener_config = 7;
 }
 
 message SnmpV3User {
@@ -66,6 +60,4 @@ message ListenerConfig {
   int32  num_threads = 4;
 }
 
-message TrapsConfig {
-  repeated TrapsBaseConfig traps_base_config = 1;
-}
+

--- a/shared-lib/protobuf/src/main/proto/traps-config.proto
+++ b/shared-lib/protobuf/src/main/proto/traps-config.proto
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+
+package opennms.sink.traps;
+option java_multiple_files = true;
+option java_package = "org.opennms.sink.traps.contract";
+
+message TrapsBaseConfig {
+  string snmp_trap_address = 1;
+  int32 snmp_trap_port = 2;
+  bool new_suspect_on_trap = 3;
+  bool include_raw_message = 4;
+  bool use_address_from_varbind = 5;
+  // Config specific to a location
+  // If not specified, config applies to all locations
+  optional string location = 6;
+  // Config specific to minion
+  // If not specified, config applies to all minions
+  optional string system_id = 7;
+  repeated SnmpV3User snmp_v3_user = 8;
+  ListenerConfig listener_config = 9;
+}
+
+message SnmpV3User {
+  string engine_id = 1;
+  string security_name = 2;
+  int32 security_level = 3;
+  string auth_passphrase = 4;
+  string privacy_passphrase = 5;
+  string auth_protocol = 6;
+  string privacy_protocol = 7;
+}
+
+message ListenerConfig {
+  int32  queue_size = 1;
+  int32  batch_size = 2;
+  int32  batch_interval_ms = 3;
+  int32  num_threads = 4;
+}
+
+message TrapsConfig {
+  repeated TrapsBaseConfig traps_base_config = 1;
+}


### PR DESCRIPTION
## Description
TrapListener will be a Listener for task-sets
TrapConfig pushed from Core via TaskSet.

## Jira link(s)
- https://issues.opennms.org/browse/HS-493


## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
