### PR TITLE
HS-451: Add time range to metrics query

### DIFF
--- a/rest-server/src/main/java/org/opennms/horizon/server/model/TSResult.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/TSResult.java
@@ -39,4 +39,5 @@ import lombok.Setter;
 public class TSResult {
     private Map<String, String> metric;
     List<Double> value;
+    List<List<Double>> values;
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/model/TimeRangeUnit.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/model/TimeRangeUnit.java
@@ -26,13 +26,18 @@
  *     http://www.opennms.com/
  *******************************************************************************/
 
-package org.opennms.horizon.server.service;
+package org.opennms.horizon.server.model;
 
-import java.util.Map;
+public enum TimeRangeUnit {
+    SECOND("s"),
+    MINUTE("m"),
+    HOUR("h"),
+    DAY("d"),
+    WEEK("w");
 
-import org.opennms.horizon.server.model.TimeSeriesQueryResult;
-import reactor.core.publisher.Mono;
+    public final String value;
 
-public interface TSDBService {
-    Mono<TimeSeriesQueryResult> getMetric(String name, Map<String, String> labels);
+    TimeRangeUnit(String value) {
+        this.value = value;
+    }
 }

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 server:
   port: 9090
 
+spring:
+  jackson:
+    default-property-inclusion: non_null
+
 # graphql
 graphql:
   spqr:


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
After the system is ready, try querying metrics from the BFF GraphQL playground at http://localhost:8123/api/gui

The query string looks like the following
```query {
  metric(name: "response_time_msec", labels:{monitor: "SNMP"}, timeRange: 10, timeRangeUnit: MINUTE) {
    status
    data{resultType 
    result{metric value values}}
  }
}
```

## Jira link(s)
- https://issues.opennms.org/browse/HS-451

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
