### PR TITLE
[HS-544] Remove tilt inspector

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,4 @@
 # Tilt config #
-load('ext://tilt_inspector', 'tilt_inspector')
-tilt_inspector()
-
 secret_settings(disable_scrub=True)  ## TODO: update secret values so we can reenable scrub
 
 # Functions #


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
- Tilt inspector was used to debug Tilt itself while working on it, but is not necessary at this point. Would fail to start on certain machines.

## Jira link(s)
- https://issues.opennms.org/browse/HS-544

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
