### PR TITLE
Adjust keycloak helm chart to avoid troubles with routing.

### DIFF
--- a/charts/opennms/templates/keycloak/keycloak-deployment.yaml
+++ b/charts/opennms/templates/keycloak/keycloak-deployment.yaml
@@ -51,12 +51,8 @@ spec:
               value: kubernetes
             - name: KC_CACHE
               value: ispn
-            - name: KC_HOSTNAME
-              value: "{{ .Values.Host }}"
-            {{- if .Values.Keycloak.HostnamePort }}
-            - name: KC_HOSTNAME_PORT
-              value: "{{ .Values.Keycloak.HostnamePort }}"
-            {{- end }}
+            - name: KC_HOSTNAME_URL
+              value: "{{ .Values.Keycloak.HostnameUrl }}"
             {{- if .Values.Keycloak.HostnameAdminUrl }}
             - name: KC_HOSTNAME_ADMIN_URL
               value: "{{ .Values.Keycloak.HostnameAdminUrl }}"
@@ -75,22 +71,26 @@ spec:
                 secretKeyRef:
                   name: postgres
                   key: keycloakPwd
+            {{- if .Values.Keycloak.AdminUsername }}
             - name: KEYCLOAK_ADMIN
               valueFrom:
                 secretKeyRef:
                   key: username
                   name: {{ .Values.Keycloak.ServiceName }}-initial-admin
+            {{- end }}
+            {{- if .Values.Keycloak.AdminPassword }}
             - name: KEYCLOAK_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: password
                   name: {{ .Values.Keycloak.ServiceName }}-initial-admin
-            - name: KC_HOSTNAME_STRICT_BACKCHANNEL
+            {{- end }}
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            - name: KC_HOSTNAME_STRICT_HTTPS
               value: "false"
             - name: KC_HTTP_ENABLED
               value: "true"
-            - name: KC_HTTP_RELATIVE_PATH
-              value: "{{ .Values.Keycloak.Path }}"
             - name: KC_PROXY
               value: passthrough
             - name: jgroups.dns.query
@@ -100,6 +100,10 @@ spec:
               value: "/mnt/certificates/tls.crt"
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
               value: "/mnt/certificates/tls.key"
+            {{- end }}
+            {{- if .Values.Keycloak.JavaOpts }}
+            - name: JAVA_OPTS
+              value: "{{ .Values.Keycloak.JavaOpts }}"
             {{- end }}
           ports:
             - name: http

--- a/charts/opennms/values.yaml
+++ b/charts/opennms/values.yaml
@@ -150,7 +150,7 @@ Keycloak:
   ImagePullPolicy: IfNotPresent
   Port: 8080
   HttpsPort: 8443
-  HostnamePort: ~
+  HostnameUrl: ~
   HostnameAdminUrl: ~
   Replicas: 1
   ServiceName: onms-keycloak

--- a/tilt-helm-values.yaml
+++ b/tilt-helm-values.yaml
@@ -6,7 +6,7 @@ TLS:
   Enabled: False
 Keycloak:
   AdminPassword: admin
-  HostnamePort: 8123
+  HostnameUrl: http://localhost:8123/auth
   HostnameAdminUrl: http://localhost:8123/auth
 
 OpenNMS:


### PR DESCRIPTION
I did verify Keycloak configuration and 19.0.3 (.2 probably too) have a bug related to detection of https from actual configuration. There are few options which are available the most stable seem to be HOSTNAME_URL which allows to pass https, host and port all together. The https detection with hostname alone doesn't work and needs KC_HOSTNAME_STRICT_HTTPS to be set to false, which is undocumented feature.

Shipping it for now, as there is a pending issue in Keycloak itself: keycloak/keycloak#15287, which awaits resolution in release later than we use.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
