### PR TITLE
HS-473: Prevent device creation if ipAddress already present for location

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/grpc/DeviceGrpcService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/grpc/DeviceGrpcService.java
@@ -10,28 +10,32 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.opennms.horizon.inventory.dto.DeviceCreateDTO;
 import org.opennms.horizon.inventory.dto.DeviceServiceGrpc;
+import org.opennms.horizon.inventory.dto.IpInterfaceDTO;
 import org.opennms.horizon.inventory.dto.NodeDTO;
 import org.opennms.horizon.inventory.mapper.NodeMapper;
 import org.opennms.horizon.inventory.model.Node;
+import org.opennms.horizon.inventory.service.IpInterfaceService;
 import org.opennms.horizon.inventory.service.NodeService;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
 public class DeviceGrpcService extends DeviceServiceGrpc.DeviceServiceImplBase {
     private final NodeService nodeService;
+    private final IpInterfaceService ipInterfaceService;
     private final NodeMapper nodeMapper;
     private final TenantLookup tenantLookup;
 
     @Override
     @Transactional
     public void createDevice(DeviceCreateDTO request, StreamObserver<NodeDTO> responseObserver) {
-        boolean valid = validateInput(request, responseObserver);
+        Optional<String> tenantId = tenantLookup.lookupTenantId(Context.current());
+        boolean valid = validateInput(request, tenantId.orElseThrow(), responseObserver);
 
         if (valid) {
-            Optional<String> tenantId = tenantLookup.lookupTenantId(Context.current());
             Node node = nodeService.createDevice(request, tenantId.orElseThrow());
 
             responseObserver.onNext(nodeMapper.modelToDTO(node));
@@ -39,17 +43,28 @@ public class DeviceGrpcService extends DeviceServiceGrpc.DeviceServiceImplBase {
         }
     }
 
-    private boolean validateInput(DeviceCreateDTO request, StreamObserver<NodeDTO> responseObserver) {
+    private boolean validateInput(DeviceCreateDTO request, String tenantId, StreamObserver<NodeDTO> responseObserver) {
         boolean valid = true;
-        // TODO: Check there isn't a node already with same IpInterface and location
-        
-        if (request.hasManagementIp() && !InetAddresses.isInetAddress(request.getManagementIp())) {
-            valid = false;
-            Status status = Status.newBuilder()
-                .setCode(Code.INVALID_ARGUMENT_VALUE)
-                .setMessage("Bad management_ip: " + request.getManagementIp())
-                .build();
-            responseObserver.onError(StatusProto.toStatusRuntimeException(status));
+
+        if (request.hasManagementIp()) {
+            if (!InetAddresses.isInetAddress(request.getManagementIp())) {
+                valid = false;
+                Status status = Status.newBuilder()
+                    .setCode(Code.INVALID_ARGUMENT_VALUE)
+                    .setMessage("Bad management_ip: " + request.getManagementIp())
+                    .build();
+                responseObserver.onError(StatusProto.toStatusRuntimeException(status));
+            } else {
+                List<IpInterfaceDTO> ipList = ipInterfaceService.findByIpAddressAndLocationAndTenantId(request.getManagementIp(), request.getLocation(), tenantId);
+                if (!ipList.isEmpty()) {
+                    valid = false;
+                    Status status = Status.newBuilder()
+                        .setCode(Code.ALREADY_EXISTS_VALUE)
+                        .setMessage("Ip address already exists for location")
+                        .build();
+                    responseObserver.onError(StatusProto.toStatusRuntimeException(status));
+                }
+            }
         }
 
         return valid;

--- a/inventory/src/main/java/org/opennms/horizon/inventory/grpc/GrpcConfig.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/grpc/GrpcConfig.java
@@ -30,6 +30,7 @@ package org.opennms.horizon.inventory.grpc;
 
 import java.util.Arrays;
 
+import org.opennms.horizon.inventory.service.IpInterfaceService;
 import org.opennms.horizon.inventory.service.MonitoringLocationService;
 import org.opennms.horizon.inventory.service.MonitoringSystemService;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +53,7 @@ public class GrpcConfig {
     @Value("${grpc.server.port:" + DEFAULT_GRPC_PORT +"}")
     private int port;
     private final NodeService nodeService;
+    private final IpInterfaceService ipInterfaceService;
     private final NodeMapper nodeMapper;
 
 
@@ -72,7 +74,7 @@ public class GrpcConfig {
 
     @Bean
     public DeviceGrpcService createDeviceService(TenantLookup tenantLookup) {
-        return new DeviceGrpcService(nodeService, nodeMapper, tenantLookup);
+        return new DeviceGrpcService(nodeService, ipInterfaceService, nodeMapper, tenantLookup);
     }
 
     @Bean(destroyMethod = "stopServer")

--- a/inventory/src/main/java/org/opennms/horizon/inventory/repository/IpInterfaceRepository.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/repository/IpInterfaceRepository.java
@@ -2,11 +2,16 @@ package org.opennms.horizon.inventory.repository;
 
 import java.util.List;
 
+import com.vladmihalcea.hibernate.type.basic.Inet;
 import org.opennms.horizon.inventory.model.IpInterface;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface IpInterfaceRepository extends JpaRepository<IpInterface, Long> {
     List<IpInterface> findByTenantId(String tenantId);
+
+    @Query("select ip from IpInterface ip inner join Node n on ip.tenantId = n.tenantId inner join MonitoringLocation ml on n.tenantId = ml.tenantId where ip.ipAddress = ?1 and ml.location = ?2 and ip.tenantId = ?3")
+    List<IpInterface> findByIpAddressAndLocationAndTenantId(Inet ipAddress, String location, String tenantId);
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/IpInterfaceService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/IpInterfaceService.java
@@ -1,18 +1,15 @@
 package org.opennms.horizon.inventory.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import com.vladmihalcea.hibernate.type.basic.Inet;
+import lombok.RequiredArgsConstructor;
 import org.opennms.horizon.inventory.dto.IpInterfaceDTO;
 import org.opennms.horizon.inventory.mapper.IpInterfaceMapper;
 import org.opennms.horizon.inventory.model.IpInterface;
-import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.repository.IpInterfaceRepository;
-import org.opennms.horizon.inventory.repository.NodeRepository;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +20,14 @@ public class IpInterfaceService {
 
     public List<IpInterfaceDTO> findByTenantId(String tenantId) {
         List<IpInterface> all = modelRepo.findByTenantId(tenantId);
+        return all
+            .stream()
+            .map(mapper::modelToDTO)
+            .collect(Collectors.toList());
+    }
+
+    public List<IpInterfaceDTO> findByIpAddressAndLocationAndTenantId(String ipAddress, String location, String tenantId) {
+        List<IpInterface> all = modelRepo.findByIpAddressAndLocationAndTenantId(new Inet(ipAddress), location, tenantId);
         return all
             .stream()
             .map(mapper::modelToDTO)

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoredServiceService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoredServiceService.java
@@ -1,20 +1,14 @@
 package org.opennms.horizon.inventory.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.opennms.horizon.inventory.dto.MonitoredServiceDTO;
 import org.opennms.horizon.inventory.mapper.MonitoredServiceMapper;
-import org.opennms.horizon.inventory.model.IpInterface;
 import org.opennms.horizon.inventory.model.MonitoredService;
-import org.opennms.horizon.inventory.model.MonitoredServiceType;
-import org.opennms.horizon.inventory.repository.IpInterfaceRepository;
 import org.opennms.horizon.inventory.repository.MonitoredServiceRepository;
-import org.opennms.horizon.inventory.repository.MonitoredServiceTypeRepository;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoredServiceTypeService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoredServiceTypeService.java
@@ -1,16 +1,14 @@
 package org.opennms.horizon.inventory.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.opennms.horizon.inventory.dto.MonitoredServiceTypeDTO;
 import org.opennms.horizon.inventory.mapper.MonitoredServiceTypeMapper;
 import org.opennms.horizon.inventory.model.MonitoredServiceType;
 import org.opennms.horizon.inventory.repository.MonitoredServiceTypeRepository;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringLocationService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringLocationService.java
@@ -1,16 +1,15 @@
 package org.opennms.horizon.inventory.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.opennms.horizon.inventory.dto.MonitoringLocationDTO;
 import org.opennms.horizon.inventory.mapper.MonitoringLocationMapper;
 import org.opennms.horizon.inventory.model.MonitoringLocation;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringSystemService.java
@@ -1,11 +1,6 @@
 package org.opennms.horizon.inventory.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.opennms.cloud.grpc.minion.Identity;
 import org.opennms.horizon.grpc.heartbeat.contract.HeartbeatMessage;
 import org.opennms.horizon.inventory.dto.MonitoringSystemDTO;
@@ -16,7 +11,11 @@ import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.MonitoringSystemRepository;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/SnmpInterfaceService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/SnmpInterfaceService.java
@@ -1,18 +1,14 @@
 package org.opennms.horizon.inventory.service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.opennms.horizon.inventory.dto.SnmpInterfaceDTO;
 import org.opennms.horizon.inventory.mapper.SnmpInterfaceMapper;
-import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.model.SnmpInterface;
-import org.opennms.horizon.inventory.repository.NodeRepository;
 import org.opennms.horizon.inventory.repository.SnmpInterfaceRepository;
 import org.springframework.stereotype.Service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/inventory/src/main/resources/db/changelog/hs-0.1.0/tables/monitoring-location.xml
+++ b/inventory/src/main/resources/db/changelog/hs-0.1.0/tables/monitoring-location.xml
@@ -19,13 +19,19 @@
             </column>
 
             <column name="location" type="TEXT">
-                <constraints nullable="false" unique="true"/>
+                <constraints nullable="false"/>
             </column>
 
         </createTable>
 
         <addPrimaryKey tableName="monitoring_location" columnNames="id"
                        constraintName="pk_monitoring_location_id"/>
+
+        <addUniqueConstraint
+            columnNames="tenant_id, location"
+            constraintName="location_constraint"
+            tableName="monitoring_location"
+        />
 
     </changeSet>
 </databaseChangeLog>

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/DeviceGrpcIT.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/DeviceGrpcIT.java
@@ -2,6 +2,7 @@ package org.opennms.horizon.inventory.grpc;
 
 import com.google.rpc.Code;
 import com.google.rpc.Status;
+import com.vladmihalcea.hibernate.type.basic.Inet;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import org.junit.jupiter.api.AfterEach;
@@ -12,12 +13,17 @@ import org.opennms.horizon.inventory.PostgresInitializer;
 import org.opennms.horizon.inventory.dto.DeviceCreateDTO;
 import org.opennms.horizon.inventory.dto.DeviceServiceGrpc;
 import org.opennms.horizon.inventory.dto.NodeDTO;
+import org.opennms.horizon.inventory.model.IpInterface;
+import org.opennms.horizon.inventory.model.MonitoringLocation;
+import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.repository.IpInterfaceRepository;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.NodeRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -65,6 +71,90 @@ class DeviceGrpcIT extends GrpcTestBase {
         NodeDTO node = serviceStub.createDevice(createDTO);
 
         assertEquals(label, node.getNodeLabel());
+    }
+
+    @Test
+    void testCreateDeviceExistingIpAddress() throws Exception {
+        String location = "location";
+        String ip = "127.0.0.1";
+        String label = "label";
+
+        setupGrpc();
+        populateTables(location, ip);
+        initStub();
+
+        DeviceCreateDTO createDTO = DeviceCreateDTO.newBuilder()
+            .setLocation(location)
+            .setLabel(label)
+            .setManagementIp(ip)
+            .build();
+
+        StatusRuntimeException exception = Assertions.assertThrows(StatusRuntimeException.class, ()->serviceStub.createDevice(createDTO));
+        Status status = StatusProto.fromThrowable(exception);
+        assertThat(status.getCode()).isEqualTo(Code.ALREADY_EXISTS_VALUE);
+        assertThat(status.getMessage()).isEqualTo("Ip address already exists for location");
+    }
+
+    @Test
+    void testCreateDeviceExistingIpAddressDifferentTenantId() throws Exception {
+        String location = "location";
+        String ip = "127.0.0.1";
+        String label = "label";
+
+        setupGrpcWithDifferentTenantID();
+        populateTables(location, ip);
+        initStub();
+
+        DeviceCreateDTO createDTO = DeviceCreateDTO.newBuilder()
+            .setLocation(location)
+            .setLabel(label)
+            .setManagementIp(ip)
+            .build();
+
+        NodeDTO node = serviceStub.createDevice(createDTO);
+
+        assertEquals(label, node.getNodeLabel());
+    }
+
+    @Test
+    void testCreateDeviceExistingIpAddressDifferentLocation() throws Exception {
+        String location = "location";
+        String ip = "127.0.0.1";
+        String label = "label";
+
+        setupGrpc();
+        populateTables(location, ip);
+        initStub();
+
+        DeviceCreateDTO createDTO = DeviceCreateDTO.newBuilder()
+            .setLocation("different")
+            .setLabel(label)
+            .setManagementIp(ip)
+            .build();
+
+        NodeDTO node = serviceStub.createDevice(createDTO);
+
+        assertEquals(label, node.getNodeLabel());
+    }
+
+    private void populateTables(String location, String ip) {
+        MonitoringLocation ml = new MonitoringLocation();
+        ml.setLocation(location);
+        ml.setTenantId(tenantId);
+        MonitoringLocation savedML = monitoringLocationRepository.save(ml);
+
+        Node node = new Node();
+        node.setTenantId(tenantId);
+        node.setNodeLabel("label");
+        node.setMonitoringLocation(savedML);
+        node.setCreateTime(LocalDateTime.now());
+        Node savedNode = nodeRepository.save(node);
+
+        IpInterface ipInterface = new IpInterface();
+        ipInterface.setTenantId(tenantId);
+        ipInterface.setIpAddress(new Inet(ip));
+        ipInterface.setNode(savedNode);
+        IpInterface savedIpInterface = ipInterfaceRepository.save(ipInterface);
     }
 
     @Test


### PR DESCRIPTION
## Description
Prevent device creation if ipAddress already present for location

## Jira link(s)
- https://issues.opennms.org/browse/HS-473

## Flagged for review
Is there a better way of writing IpInterfaceRepository lines 15 and 16: (Can I get rid of the query, and do some JPA magic instead?)

    @Query("select ip from IpInterface ip inner join Node n on ip.tenantId = n.tenantId inner join MonitoringLocation ml on n.tenantId = ml.tenantId where ip.ipAddress = ?1 and ml.location = ?2 and ip.tenantId = ?3")
    List<IpInterface> findByIpAddressAndLocationAndTenantId(Inet ipAddress, String location, String tenantId);

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
