### PR TITLE
HS-609 Make sure docker args are promoted at build stage

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -24,15 +24,15 @@ CMD ["--port", "8080"]
 # Builds the app for production
 FROM sources as build
 
-RUN ["yarn", "run", "build"]
-
-# Serves prod build with nginx
-FROM nginx:1.23.1-alpine as production
-
 ARG VITE_BASE_URL
 ARG VITE_KEYCLOAK_URL
 ARG VITE_KEYCLOAK_REALM
 ARG VITE_KEYCLOAK_CLIENT_ID
+
+RUN ["yarn", "run", "build"]
+
+# Serves prod build with nginx
+FROM nginx:1.23.1-alpine as production
 
 # Configure nginx
 COPY --link /nginx /etc/nginx


### PR DESCRIPTION
## Description
Currently there are predefined build arguments which can be passed to override defaults assumed by UI build. Sadly they do not work, as they are defined in wrong stage. This means that UI container can not be built with different target than development environment. By moving `ARG` section to build stage where actual JS output is being produced image can be parametrized at build time without necessity to explicitly declare `ENV` vars (which are meaningless for generated JS code).

## Jira link(s)
- https://issues.opennms.org/browse/HS-609

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
