### PR TITLE
HS-605: Send trap config to minion

### DIFF
--- a/inventory/pom.xml
+++ b/inventory/pom.xml
@@ -147,6 +147,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-adapter-core</artifactId>
+            <version>${keycloak.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringLocationService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/MonitoringLocationService.java
@@ -30,7 +30,15 @@ public class MonitoringLocationService {
         return modelRepo.findByLocationAndTenantId(location, tenantId).map(mapper::modelToDTO);
     }
 
-    public Optional<MonitoringLocationDTO> getByIdAndTenantId(long id, String tenantId){
+    public Optional<MonitoringLocationDTO> getByIdAndTenantId(long id, String tenantId) {
         return modelRepo.findByIdAndTenantId(id, tenantId).map(mapper::modelToDTO);
+    }
+
+    public List<MonitoringLocationDTO> findAll() {
+        List<MonitoringLocation> all = modelRepo.findAll();
+        return all
+            .stream()
+            .map(mapper::modelToDTO)
+            .collect(Collectors.toList());
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
@@ -98,7 +98,7 @@ public class NodeService {
             newLocation.setLocation(location);
 
             MonitoringLocation saved = monitoringLocationRepository.save(newLocation);
-            trapConfigService.sendTrapConfigToMinion(saved.getTenantId(), saved.getLocation());
+            trapConfigService.sendTrapConfigToMinion(saved.getLocation());
 
             return saved;
         }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/NodeService.java
@@ -53,6 +53,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class NodeService {
+    private final TrapConfigService trapConfigService;
     private final NodeRepository nodeRepository;
     private final MonitoringLocationRepository monitoringLocationRepository;
     private final IpInterfaceRepository ipInterfaceRepository;
@@ -96,7 +97,10 @@ public class NodeService {
             newLocation.setTenantId(tenantId);
             newLocation.setLocation(location);
 
-            return monitoringLocationRepository.save(newLocation);
+            MonitoringLocation saved = monitoringLocationRepository.save(newLocation);
+            trapConfigService.sendTrapConfigToMinion(saved.getTenantId(), saved.getLocation());
+
+            return saved;
         }
     }
 

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
 package org.opennms.horizon.inventory.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,12 +64,12 @@ public class TrapConfigService {
         List<MonitoringLocationDTO> allLocations = monitoringLocationService.findAll();
 
         for(MonitoringLocationDTO dto : allLocations) {
-            sendTrapConfigToMinion(dto.getTenantId(), dto.getLocation());
+            sendTrapConfigToMinion(dto.getLocation());
         }
     }
 
-    public void sendTrapConfigToMinion(String tenantId, String location) {
-        TrapConfigBean trapConfigBean = readTrapConfig(tenantId);
+    public void sendTrapConfigToMinion(String location) {
+        TrapConfigBean trapConfigBean = readTrapConfig();
         TrapConfig trapConfig = mapBeanToProto(trapConfigBean);
         publishTrapConfig(location, trapConfig);
     }
@@ -87,7 +114,7 @@ public class TrapConfigService {
         taskSetPublisher.publishTaskSet(location, taskSetManager.getTaskSet(location));
     }
 
-    private TrapConfigBean readTrapConfig(String tenantId) {
+    private TrapConfigBean readTrapConfig() {
         try {
             URL url = this.getClass().getResource("/trapd-config.json");
             return objectMapper.readValue(url, TrapConfigBean.class);

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
@@ -1,0 +1,98 @@
+package org.opennms.horizon.inventory.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.Any;
+import lombok.RequiredArgsConstructor;
+import org.opennms.horizon.inventory.dto.MonitoringLocationDTO;
+import org.opennms.horizon.inventory.service.taskset.manager.TaskSetManager;
+import org.opennms.horizon.inventory.service.trapconfig.TrapConfigBean;
+import org.opennms.sink.traps.contract.ListenerConfig;
+import org.opennms.sink.traps.contract.SnmpV3User;
+import org.opennms.sink.traps.contract.TrapConfig;
+import org.opennms.taskset.contract.TaskDefinition;
+import org.opennms.taskset.contract.TaskType;
+import org.opennms.taskset.service.api.TaskSetPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TrapConfigService {
+    private static final Logger LOG = LoggerFactory.getLogger(TrapConfigService.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MonitoringLocationService monitoringLocationService;
+    private final TaskSetManager taskSetManager;
+    private final TaskSetPublisher taskSetPublisher;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void sendTrapConfigToMinionAfterStartup() {
+        List<MonitoringLocationDTO> allLocations = monitoringLocationService.findAll();
+
+        for(MonitoringLocationDTO dto : allLocations) {
+            sendTrapConfigToMinion(dto.getTenantId(), dto.getLocation());
+        }
+    }
+
+    public void sendTrapConfigToMinion(String tenantId, String location) {
+        TrapConfigBean trapConfigBean = readTrapConfig(tenantId);
+        TrapConfig trapConfig = mapBeanToProto(trapConfigBean);
+        publishTrapConfig(location, trapConfig);
+    }
+
+    private TrapConfig mapBeanToProto(TrapConfigBean config) {
+        return TrapConfig.newBuilder()
+            .setSnmpTrapAddress(config.getSnmpTrapAddress())
+            .setSnmpTrapPort(config.getSnmpTrapPort())
+            .setNewSuspectOnTrap(config.getNewSuspectOnTrap())
+            .setIncludeRawMessage(config.isIncludeRawMessage())
+//            .setUseAddressFromVarbind(config.shouldUseAddressFromVarbind())
+            .setListenerConfig(ListenerConfig.newBuilder()
+                .setBatchIntervalMs(config.getBatchIntervalMs())
+                .setBatchSize(config.getBatchSize())
+                .setQueueSize(config.getQueueSize())
+                .setNumThreads(config.getNumThreads()))
+//            .addAllSnmpV3User(mapSnmpV3Users(config))
+            .build();
+    }
+
+//    private List<SnmpV3User> mapSnmpV3Users(TrapConfigBean config) {
+//        return config.getSnmpV3Users().stream().map(snmpV3User -> {
+//            return SnmpV3User.newBuilder()
+//                .setEngineId(snmpV3User.getEngineId())
+//                .setAuthPassphrase(snmpV3User.getAuthPassphrase())
+//                .setAuthProtocol(snmpV3User.getAuthProtocol())
+//                .setPrivacyPassphrase(snmpV3User.getPrivacyPassphrase())
+//                .setPrivacyProtocol(snmpV3User.getPrivacyProtocol())
+//                .build();
+//        }).collect(Collectors.toList());
+//    }
+
+    private void publishTrapConfig(String location, TrapConfig trapConfig) {
+        TaskDefinition taskDefinition = TaskDefinition.newBuilder()
+            .setId("traps-config")
+            .setPluginName("trapd.listener.config")
+            .setType(TaskType.LISTENER)
+            .setConfiguration(Any.pack(trapConfig))
+            .build();
+
+        taskSetManager.addTaskSet(location, taskDefinition);
+        taskSetPublisher.publishTaskSet(location, taskSetManager.getTaskSet(location));
+    }
+
+    private TrapConfigBean readTrapConfig(String tenantId) {
+        try {
+            URL url = this.getClass().getResource("/trapd-config.json");
+            return objectMapper.readValue(url, TrapConfigBean.class);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
@@ -59,21 +59,21 @@ public class TrapConfigService {
                 .setBatchSize(config.getBatchSize())
                 .setQueueSize(config.getQueueSize())
                 .setNumThreads(config.getNumThreads()))
-//            .addAllSnmpV3User(mapSnmpV3Users(config))
+            .addAllSnmpV3User(mapSnmpV3Users(config))
             .build();
     }
 
-//    private List<SnmpV3User> mapSnmpV3Users(TrapConfigBean config) {
-//        return config.getSnmpV3Users().stream().map(snmpV3User -> {
-//            return SnmpV3User.newBuilder()
-//                .setEngineId(snmpV3User.getEngineId())
-//                .setAuthPassphrase(snmpV3User.getAuthPassphrase())
-//                .setAuthProtocol(snmpV3User.getAuthProtocol())
-//                .setPrivacyPassphrase(snmpV3User.getPrivacyPassphrase())
-//                .setPrivacyProtocol(snmpV3User.getPrivacyProtocol())
-//                .build();
-//        }).collect(Collectors.toList());
-//    }
+    private List<SnmpV3User> mapSnmpV3Users(TrapConfigBean config) {
+        return config.getSnmpV3Users().stream().map(snmpV3User -> {
+            return SnmpV3User.newBuilder()
+                .setEngineId(snmpV3User.getEngineId())
+                .setAuthPassphrase(snmpV3User.getAuthPassphrase())
+                .setAuthProtocol(snmpV3User.getAuthProtocol())
+                .setPrivacyPassphrase(snmpV3User.getPrivacyPassphrase())
+                .setPrivacyProtocol(snmpV3User.getPrivacyProtocol())
+                .build();
+        }).collect(Collectors.toList());
+    }
 
     private void publishTrapConfig(String location, TrapConfig trapConfig) {
         TaskDefinition taskDefinition = TaskDefinition.newBuilder()

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/SnmpV3User.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/SnmpV3User.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2011-2014 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2014 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.service.trapconfig;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Objects;
+
+public class SnmpV3User {
+
+    private String engineId;
+    private String securityName;
+    private Integer securityLevel;
+    private String authPassphrase;
+    private String privacyPassphrase;
+    private String authProtocol;
+    private String privacyProtocol;
+
+    public SnmpV3User() {
+        super();
+    }
+
+    public SnmpV3User(String securityName, String authenticationProtocol,
+            String authenticationPassphrase, String privacyProtocol,
+            String privacyPassphrase) {
+        super();
+        this.securityName = securityName;
+        this.authProtocol = authenticationProtocol;
+        this.authPassphrase = authenticationPassphrase;
+        this.privacyProtocol = privacyProtocol;
+        this.privacyPassphrase = privacyPassphrase;
+    }
+
+    public SnmpV3User(String engineId, String securityName, String authenticationProtocol,
+            String authenticationPassphrase, String privacyProtocol, String privacyPassphrase) {
+        this(securityName, authenticationProtocol, authenticationPassphrase, privacyProtocol, privacyPassphrase);
+        this.engineId = engineId;
+    }
+
+    public String getEngineId() {
+        return engineId;
+    }
+
+    public void setEngineId(String engineId) {
+        this.engineId = engineId;
+    }
+
+    public String getSecurityName() {
+        return securityName;
+    }
+
+    public void setSecurityName(String securityName) {
+        this.securityName = securityName;
+    }
+
+    public Integer getSecurityLevel() {
+        return securityLevel;
+    }
+
+    public void setSecurityLevel(Integer securityLevel) {
+        this.securityLevel = securityLevel;
+    }
+
+    public String getAuthPassphrase() {
+        return authPassphrase;
+    }
+
+    public void setAuthPassphrase(String authenticationPassphrase) {
+        this.authPassphrase = authenticationPassphrase;
+    }
+
+    public String getPrivacyPassphrase() {
+        return privacyPassphrase;
+    }
+
+    public void setPrivacyPassphrase(String privacyPassphrase) {
+        this.privacyPassphrase = privacyPassphrase;
+    }
+
+    public String getAuthProtocol() {
+        return authProtocol;
+    }
+
+    public void setAuthProtocol(String authenticationProtocol) {
+        this.authProtocol = authenticationProtocol;
+    }
+
+    public String getPrivacyProtocol() {
+        return privacyProtocol;
+    }
+
+    public void setPrivacyProtocol(String privacyProtocol) {
+        this.privacyProtocol = privacyProtocol;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(engineId, securityName, securityLevel, authPassphrase, privacyPassphrase, authProtocol, privacyProtocol);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SnmpV3User that = (SnmpV3User) o;
+        return Objects.equals(engineId, that.engineId) &&
+                Objects.equals(securityName, that.securityName) &&
+                Objects.equals(securityLevel, that.securityLevel) &&
+                Objects.equals(authPassphrase, that.authPassphrase) &&
+                Objects.equals(privacyPassphrase, that.privacyPassphrase) &&
+                Objects.equals(authProtocol, that.authProtocol) &&
+                Objects.equals(privacyProtocol, that.privacyProtocol);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("authPassphrase", authPassphrase)
+            .append("authProtocol", authProtocol)
+            .append("engineId", engineId)
+            .append("privPassPhrase", privacyPassphrase)
+            .append("privProtocol", privacyProtocol)
+            .append("securityName", securityName)
+            .toString();
+    }
+}

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/TrapConfigBean.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/TrapConfigBean.java
@@ -1,0 +1,152 @@
+package org.opennms.horizon.inventory.service.trapconfig;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.opennms.sink.traps.contract.SnmpV3User;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "snmpTrapAddress",
+    "snmpTrapPort",
+    "newSuspectOnTrap",
+    "snmpV3Users",
+    "includeRawMessage",
+    "batchSize",
+    "queueSize",
+    "numThreads",
+    "batchIntervalMs"
+})
+@Generated("jsonschema2pojo")
+public class TrapConfigBean {
+
+    @JsonProperty("snmpTrapAddress")
+    private String snmpTrapAddress;
+    @JsonProperty("snmpTrapPort")
+    private Integer snmpTrapPort;
+    @JsonProperty("newSuspectOnTrap")
+    private Boolean newSuspectOnTrap;
+    @JsonProperty("snmpV3Users")
+    private List<Object> snmpV3Users = null;
+    @JsonProperty("includeRawMessage")
+    private Boolean includeRawMessage;
+    @JsonProperty("batchSize")
+    private Integer batchSize;
+    @JsonProperty("queueSize")
+    private Integer queueSize;
+    @JsonProperty("numThreads")
+    private Integer numThreads;
+    @JsonProperty("batchIntervalMs")
+    private Integer batchIntervalMs;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("snmpTrapAddress")
+    public String getSnmpTrapAddress() {
+        return snmpTrapAddress;
+    }
+
+    @JsonProperty("snmpTrapAddress")
+    public void setSnmpTrapAddress(String snmpTrapAddress) {
+        this.snmpTrapAddress = snmpTrapAddress;
+    }
+
+    @JsonProperty("snmpTrapPort")
+    public Integer getSnmpTrapPort() {
+        return snmpTrapPort;
+    }
+
+    @JsonProperty("snmpTrapPort")
+    public void setSnmpTrapPort(Integer snmpTrapPort) {
+        this.snmpTrapPort = snmpTrapPort;
+    }
+
+    @JsonProperty("newSuspectOnTrap")
+    public Boolean getNewSuspectOnTrap() {
+        return newSuspectOnTrap;
+    }
+
+    @JsonProperty("newSuspectOnTrap")
+    public void setNewSuspectOnTrap(Boolean newSuspectOnTrap) {
+        this.newSuspectOnTrap = newSuspectOnTrap;
+    }
+
+    @JsonProperty("snmpV3Users")
+    public List<Object> getSnmpV3Users() {
+        // TODO: Change Object to SNMPV3User.
+        return snmpV3Users;
+    }
+
+    @JsonProperty("snmpV3Users")
+    public void setSnmpV3Users(List<Object> snmpV3Users) {
+        this.snmpV3Users = snmpV3Users;
+    }
+
+    @JsonProperty("includeRawMessage")
+    public Boolean isIncludeRawMessage() {
+        return includeRawMessage;
+    }
+
+    @JsonProperty("includeRawMessage")
+    public void setIncludeRawMessage(Boolean includeRawMessage) {
+        this.includeRawMessage = includeRawMessage;
+    }
+
+    @JsonProperty("batchSize")
+    public Integer getBatchSize() {
+        return batchSize;
+    }
+
+    @JsonProperty("batchSize")
+    public void setBatchSize(Integer batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    @JsonProperty("queueSize")
+    public Integer getQueueSize() {
+        return queueSize;
+    }
+
+    @JsonProperty("queueSize")
+    public void setQueueSize(Integer queueSize) {
+        this.queueSize = queueSize;
+    }
+
+    @JsonProperty("numThreads")
+    public Integer getNumThreads() {
+        return numThreads;
+    }
+
+    @JsonProperty("numThreads")
+    public void setNumThreads(Integer numThreads) {
+        this.numThreads = numThreads;
+    }
+
+    @JsonProperty("batchIntervalMs")
+    public Integer getBatchIntervalMs() {
+        return batchIntervalMs;
+    }
+
+    @JsonProperty("batchIntervalMs")
+    public void setBatchIntervalMs(Integer batchIntervalMs) {
+        this.batchIntervalMs = batchIntervalMs;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/TrapConfigBean.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/TrapConfigBean.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import org.opennms.sink.traps.contract.SnmpV3User;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -34,7 +33,7 @@ public class TrapConfigBean {
     @JsonProperty("newSuspectOnTrap")
     private Boolean newSuspectOnTrap;
     @JsonProperty("snmpV3Users")
-    private List<Object> snmpV3Users = null;
+    private List<SnmpV3User> snmpV3Users = null;
     @JsonProperty("includeRawMessage")
     private Boolean includeRawMessage;
     @JsonProperty("batchSize")
@@ -79,13 +78,12 @@ public class TrapConfigBean {
     }
 
     @JsonProperty("snmpV3Users")
-    public List<Object> getSnmpV3Users() {
-        // TODO: Change Object to SNMPV3User.
+    public List<SnmpV3User> getSnmpV3Users() {
         return snmpV3Users;
     }
 
     @JsonProperty("snmpV3Users")
-    public void setSnmpV3Users(List<Object> snmpV3Users) {
+    public void setSnmpV3Users(List<SnmpV3User> snmpV3Users) {
         this.snmpV3Users = snmpV3Users;
     }
 

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/TrapConfigBean.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/trapconfig/TrapConfigBean.java
@@ -1,5 +1,33 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
 package org.opennms.horizon.inventory.service.trapconfig;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +61,7 @@ public class TrapConfigBean {
     @JsonProperty("newSuspectOnTrap")
     private Boolean newSuspectOnTrap;
     @JsonProperty("snmpV3Users")
-    private List<SnmpV3User> snmpV3Users = null;
+    private List<SnmpV3User> snmpV3Users = new ArrayList<>();
     @JsonProperty("includeRawMessage")
     private Boolean includeRawMessage;
     @JsonProperty("batchSize")

--- a/inventory/src/main/resources/trapd-config.json
+++ b/inventory/src/main/resources/trapd-config.json
@@ -1,0 +1,10 @@
+{
+  "snmpTrapAddress":"*",
+  "snmpTrapPort":10162,
+  "newSuspectOnTrap":false,"snmpV3Users":[],
+  "includeRawMessage":false,
+  "batchSize":1000,
+  "queueSize":10000,
+  "numThreads":24,
+  "batchIntervalMs":500
+}

--- a/inventory/src/main/resources/trapd-config.json
+++ b/inventory/src/main/resources/trapd-config.json
@@ -1,6 +1,6 @@
 {
   "snmpTrapAddress":"*",
-  "snmpTrapPort":10162,
+  "snmpTrapPort":1162,
   "newSuspectOnTrap":false,"snmpV3Users":[],
   "includeRawMessage":false,
   "batchSize":1000,

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/LocationGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/LocationGrpcItTest.java
@@ -35,6 +35,10 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.util.List;
 
+import com.google.protobuf.Empty;
+import com.google.protobuf.StringValue;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +64,10 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.MetadataUtils;
 
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 @SpringBootTest
 @ContextConfiguration(initializers = {SpringContextTestInitializer.class})
 class LocationGrpcItTest extends GrpcTestBase {
@@ -69,6 +77,7 @@ class LocationGrpcItTest extends GrpcTestBase {
     private MonitoringLocationRepository repo;
 
     private MonitoringLocationServiceGrpc.MonitoringLocationServiceBlockingStub serviceStub;
+
     @BeforeEach
     public void prepareData() throws VerificationException {
         location1 = new MonitoringLocation();

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcItTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcItTest.java
@@ -29,12 +29,14 @@
 package org.opennms.horizon.inventory.grpc;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterAll;
@@ -55,6 +57,8 @@ import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.repository.IpInterfaceRepository;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.NodeRepository;
+import org.opennms.taskset.contract.TaskSet;
+import org.opennms.taskset.service.contract.PublishTaskSetRequest;
 import org.opennms.taskset.service.contract.TaskSetServiceGrpc;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.grpc;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.opennms.horizon.inventory.SpringContextTestInitializer;
+import org.opennms.horizon.inventory.grpc.taskset.TestTaskSetGrpcService;
+import org.opennms.taskset.contract.TaskSet;
+import org.opennms.taskset.service.contract.PublishTaskSetRequest;
+import org.opennms.taskset.service.contract.TaskSetServiceGrpc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(properties = { "spring.liquibase.change-log=db/changelog/changelog-test.xml" })
+@ContextConfiguration(initializers = {SpringContextTestInitializer.class})
+class NodeGrpcStartupIntTest extends GrpcTestBase {
+    private static final int EXPECTED_TASK_DEF_COUNT = 1;
+
+    private static TestTaskSetGrpcService testGrpcService;
+
+    @BeforeAll
+    public static void setup() throws IOException {
+        testGrpcService = new TestTaskSetGrpcService();
+        server = startMockServer(TaskSetServiceGrpc.SERVICE_NAME, testGrpcService);
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        testGrpcService.reset();
+        channel.shutdown();
+    }
+
+    @AfterAll
+    public static void tearDown() throws InterruptedException {
+        server.shutdownNow();
+        server.awaitTermination();
+    }
+
+    @Test
+    void testStartup() throws Exception {
+        setupGrpc();
+
+        // TrapConfigService listens for ApplicationReadyEvent and sends the trap config for each location.
+        assertEquals(1, testGrpcService.getTimesCalled());
+
+        org.assertj.core.api.Assertions.assertThat(testGrpcService.getRequests())
+            .hasSize(1)
+            .extracting(PublishTaskSetRequest::getTaskSet)
+            .isNotNull()
+            .extracting(TaskSet::getTaskDefinitionCount)
+            .contains(EXPECTED_TASK_DEF_COUNT);
+    }
+}

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
@@ -31,7 +31,9 @@ package org.opennms.horizon.inventory.grpc;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.keycloak.common.VerificationException;
 import org.opennms.horizon.inventory.SpringContextTestInitializer;
 import org.opennms.horizon.inventory.grpc.taskset.TestTaskSetGrpcService;
 import org.opennms.taskset.contract.TaskSet;
@@ -50,6 +52,11 @@ class NodeGrpcStartupIntTest extends GrpcTestBase {
     private static final int EXPECTED_TASK_DEF_COUNT = 1;
 
     private static TestTaskSetGrpcService testGrpcService;
+
+    @BeforeEach
+    public void prepare() throws VerificationException, IOException {
+        prepareServer();
+    }
 
     @BeforeAll
     public static void setup() throws IOException {
@@ -71,8 +78,6 @@ class NodeGrpcStartupIntTest extends GrpcTestBase {
 
     @Test
     void testStartup() throws Exception {
-        setupGrpc();
-
         // TrapConfigService listens for ApplicationReadyEvent and sends the trap config for each location.
         assertEquals(1, testGrpcService.getTimesCalled());
 

--- a/inventory/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
@@ -105,7 +105,7 @@ public class NodeServiceTest {
 
         verify(ipInterfaceRepository).save(any(IpInterface.class));
         verify(monitoringLocationRepository).save(any(MonitoringLocation.class));
-        verify(trapConfigService).sendTrapConfigToMinion(tenant, location);
+        verify(trapConfigService).sendTrapConfigToMinion(location);
     }
 
     @Test
@@ -125,7 +125,7 @@ public class NodeServiceTest {
 
         verify(ipInterfaceRepository).save(any(IpInterface.class));
         verify(monitoringLocationRepository, times(0)).save(any(MonitoringLocation.class));
-        verify(trapConfigService, times(0)).sendTrapConfigToMinion(any(), any());
+        verify(trapConfigService, times(0)).sendTrapConfigToMinion(any());
     }
 
     @Test

--- a/inventory/src/test/resources/db/changelog/changelog-test.xml
+++ b/inventory/src/test/resources/db/changelog/changelog-test.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <include file="db/changelog/changelog.xml"/>
+    <include file="db/changelog/trap-config-data.xml"/>
+
+</databaseChangeLog>

--- a/inventory/src/test/resources/db/changelog/trap-config-data.xml
+++ b/inventory/src/test/resources/db/changelog/trap-config-data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="jhutc" id="trap-config-data">
+        <insert tableName="monitoring_location">
+            <column name="location" value="unknown_location"/>
+            <column name="tenant_id" value="00000000-0000-0005-0000-000000000005"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Description
Send trap config to minion

## Jira link(s)
- https://issues.opennms.org/browse/HS-605

## Flagged for review
On line 36 of TrapConfigBean, using the proto generated version of SnmpV3User gives an error when running NodeGrpcStartupIntTest:
Cannot find a (Map) Key deserializer for type [simple type, class com.google.protobuf.Descriptors$FieldDescriptor]
The solutions offered by google failed to fix the problem, so I have created a separate version based of org.opennms.horizon.shared.snmp.SnmpV3User. I can't use that version as several of the proto fields have changed name slightly.

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
