### PR TITLE
[HS-614] Locally run Minion using Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,5 +1,5 @@
 # Tilt config #
-load('ext://uibutton', 'cmd_button')
+load('ext://uibutton', 'cmd_button', 'text_input')
 
 secret_settings(disable_scrub=True)  ## TODO: update secret values so we can reenable scrub
 
@@ -226,6 +226,18 @@ cmd_button(
     resource='minion-local',
     icon_name='autorenew',
     text='Enable bundle:watch',
+)
+
+# Allows developer to send a command to the running Minion's Karaf shell
+cmd_button(
+    'minion-karaf-command',
+    argv=['sh', '-c', 'mvn -P=devAssembly org.apache.karaf.tooling:karaf-maven-plugin:client@send-command -f minion/assembly -DdevAssembly.command="$COMMAND"'],
+    resource='minion-local',
+    icon_name='electric_bolt',
+    text='Run a command in the Karaf shell',
+    inputs=[
+        text_input('COMMAND', 'Command', 'diag | grep -v Active'),
+    ],
 )
 
 ## 3rd Party Resources ##

--- a/Tiltfile
+++ b/Tiltfile
@@ -167,17 +167,33 @@ k8s_resource(
 ### Minion ###
 custom_build(
     'opennms/horizon-stream-minion',
-    'mvn install -f minion -Ddocker.image=$EXPECTED_REF -Dtest=false -DfailIfNoTests=false -DskipITs=true -DskipTests=true',
+    ['mvn', 'install', '-Ddocker.image=$EXPECTED_REF', '-Dtest=false', '-DfailIfNoTests=false', '-DskipITs=true', '-DskipUTs=true', '-DskipTests=true', '-Dfeatures.verify.skip=true'],
     deps=['./minion'],
     ignore=['**/target', '**/dependency-reduced-pom.xml'],
 )
 
 k8s_resource(
     'opennms-minion',
-    new_name='minion',
+    new_name='minion-k8s',
     port_forwards=['12022:8101', '12080:8181', '12050:5005'],
     labels=['minion'],
     trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
+local_resource(
+    'minion-local',
+    cmd=['mvn', 'install', '-Ddocker.skip=true', '-Dtest=false', '-DfailIfNoTests=false', '-DskipITs=true', '-DskipUTs=true', '-DskipTests=true', '-Dfeatures.verify.skip=true'],
+    dir='minion',
+    serve_cmd=['./bin/karaf', 'server'],
+    serve_dir='minion/assembly/target/assembly',
+    serve_env={
+        "USE_KUBERNETES": "false",
+        "LOCATION": "Default"
+    },
+    labels=['minion'],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    allow_parallel=True,
+    auto_init=False
 )
 
 ## 3rd Party Resources ##

--- a/Tiltfile
+++ b/Tiltfile
@@ -181,7 +181,7 @@ local_resource(
 # Builds karaf/docker assembly modules and produces an image.
 custom_build(
     'opennms/horizon-stream-minion',
-    'mvn install -Ddocker.image=$EXPECTED_REF -f=minion -pl=assembly,docker-assembly',
+    'mvn install -Ddocker.image=$EXPECTED_REF -f=minion -pl=assembly,docker-assembly -PdevAssembly',
     deps=['./minion'],
     ignore=['**/target', '**/dependency-reduced-pom.xml', './minion/tmp'],
 )
@@ -201,13 +201,11 @@ k8s_resource(
 # Requires the JAVA_HOME environment variable to be set, which should point to JDK 11.
 local_resource(
     'minion-local',
-    cmd='./tmp/assembly/bin/karaf stop || true && ' + # Attempts to stop karaf, proceeds on error (e.g. when karaf isn't already running).
-        'rm -rf tmp/assembly || true && ' + # Removes old tmp folder, proceeds on error (e.g. when the folder does not exist).
-        'mvn package -pl=assembly && ' + # Builds the karaf assembly module.
-        'cp -r assembly/target/assembly tmp/assembly', # Copy the assembly to 'minion/tmp`. This is done so rebuilds of the assembly module won't interfere with serve_cmd.
+    cmd='./assembly/target/dev-assembly/bin/karaf stop || true && ' + # Attempts to stop karaf, proceeds on error (e.g. when karaf isn't already running).
+        'mvn clean package -pl=assembly -PdevAssembly -DdevAssembly.outputDirectory=target/dev-assembly', # Builds the karaf assembly module.
     dir='minion',
     serve_cmd=['./bin/karaf', 'server'], # Runs Karaf locally and streams log output into Tilt
-    serve_dir='minion/tmp/assembly',
+    serve_dir='minion/assembly/target/dev-assembly',
     serve_env={
         "USE_KUBERNETES": "false",
         "LOCATION": "Default"

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,4 +1,6 @@
 # Tilt config #
+load('ext://uibutton', 'cmd_button')
+
 secret_settings(disable_scrub=True)  ## TODO: update secret values so we can reenable scrub
 
 # Functions #
@@ -215,6 +217,15 @@ local_resource(
     trigger_mode=TRIGGER_MODE_MANUAL,
     allow_parallel=True,
     auto_init=False
+)
+
+# Enables bundle:watch on the local minion
+cmd_button(
+    'minion-bundle-watch',
+    argv=['sh', '-c', 'mvn -P=devAssembly org.apache.karaf.tooling:karaf-maven-plugin:client@bundle-watch -f minion/assembly'],
+    resource='minion-local',
+    icon_name='autorenew',
+    text='Enable bundle:watch',
 )
 
 ## 3rd Party Resources ##

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,6 +1,4 @@
 # Tilt config #
-load('ext://uibutton', 'cmd_button')
-
 secret_settings(disable_scrub=True)  ## TODO: update secret values so we can reenable scrub
 
 # Functions #

--- a/minion/assembly/pom.xml
+++ b/minion/assembly/pom.xml
@@ -147,6 +147,9 @@
                 <!-- This variable is used to allow externalizing this configuration. By default, it matches karaf-maven-plugin's default. -->
                 <devAssembly.outputDirectory>${project.build.directory}/assembly</devAssembly.outputDirectory>
 
+                <!-- FIXME DO NOT COMMIT Allows execution of commands  -->
+                <devAssembly.command/>
+
                 <!-- These should only ever be present in a development profile -->
                 <devAssembly.user>admin</devAssembly.user>
                 <devAssembly.password>admin</devAssembly.password>
@@ -200,6 +203,24 @@
                                             <command>
                                                 <rank>1</rank>
                                                 <command>bundle:watch *</command>
+                                            </command>
+                                        </commands>
+
+                                        <user>${devAssembly.user}</user>
+                                        <password>${devAssembly.password}</password>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>send-command</id>
+                                    <phase>none</phase>
+                                    <goals>
+                                        <goal>client</goal>
+                                    </goals>
+                                    <configuration>
+                                        <commands>
+                                            <command>
+                                                <rank>1</rank>
+                                                <command>${devAssembly.command}</command>
                                             </command>
                                         </commands>
 

--- a/minion/assembly/pom.xml
+++ b/minion/assembly/pom.xml
@@ -139,4 +139,80 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>devAssembly</id>
+
+            <properties>
+                <!-- This variable is used to allow externalizing this configuration. By default, it matches karaf-maven-plugin's default. -->
+                <devAssembly.outputDirectory>${project.build.directory}/assembly</devAssembly.outputDirectory>
+
+                <!-- These should only ever be present in a development profile -->
+                <devAssembly.user>admin</devAssembly.user>
+                <devAssembly.password>admin</devAssembly.password>
+            </properties>
+
+            <build>
+                <resources>
+                    <resource>
+                        <directory>src/main/dev-resources</directory>
+                        <filtering>true</filtering>
+                        <includes>
+                            <!-- This should only ever be present in a development profile -->
+                            <include>etc/users.properties</include>
+                        </includes>
+                    </resource>
+                </resources>
+
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.karaf.tooling</groupId>
+                            <artifactId>karaf-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>default-assembly</id>
+                                    <goals>
+                                        <goal>assembly</goal>
+                                    </goals>
+                                    <configuration>
+                                        <workDirectory>${devAssembly.outputDirectory}</workDirectory>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>default-archive</id>
+                                    <goals>
+                                        <goal>archive</goal>
+                                    </goals>
+                                    <configuration>
+                                        <!-- needs to be set to what the assembly goal produces -->
+                                        <targetServerDirectory>${devAssembly.outputDirectory}</targetServerDirectory>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>bundle-watch</id>
+                                    <phase>none</phase>
+                                    <goals>
+                                        <goal>client</goal>
+                                    </goals>
+                                    <configuration>
+                                        <commands>
+                                            <command>
+                                                <rank>1</rank>
+                                                <command>bundle:watch *</command>
+                                            </command>
+                                        </commands>
+
+                                        <user>${devAssembly.user}</user>
+                                        <password>${devAssembly.password}</password>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/minion/assembly/src/main/dev-resources/etc/users.properties
+++ b/minion/assembly/src/main/dev-resources/etc/users.properties
@@ -1,0 +1,2 @@
+${devAssembly.user}=${devAssembly.password},_g_:admingroup
+_g_\:admingroup=group,admin,manager,viewer,systembundles,ssh


### PR DESCRIPTION
## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->
Experimental. This could be really helpful but will probably suck to maintain. I am wondering if it's worth integrating local minion runs into Tilt at all.

- Adds a devAssembly profile that produces a 'development' version of the assembly. 
- The dev assembly includes a `users.properties` file that has an `admin/admin` user. The file is filtered with variables that are named to make it clear that they're for development only.
- Adds a resource to Tilt that will compile and run a Minion locally via the Karaf assembly. This is called `minion-local` and is disabled by default.
- Adds a button to Tilt you can click to enable `bundle:watch *`. This was done with an execution on karaf-maven-plugin
- Adds a button to Tilt that lets you send arbitrary commands to Karaf
- Devs can log into the karaf shell with SSH like normal
- Renames the Kubernetes deployment of Minion to `minion-k8s`
- Disables feature verification during the dev loop for Minion and Core for speedier builds
- Requires you to set the `JAVA_HOME` environment variable and point it at JDK 11. This is only necessary for `minion-local`.

## Jira link(s)
- https://issues.opennms.org/browse/HS-614

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->
- Previous solution with the 'minion-local' resource was likely to be brittle, so I refactored it into a profile-based solution in Maven: https://github.com/OpenNMS/horizon-stream/pull/482/files/e2978ce8e146235bc593f64b024a069da7dd6789
- The assembly built by minion-local uses a subfolder within `target`. Otherwise the minion-k8s build would interfere with it, as it also builds the assembly.
- The `devAssembly` profile is very verbose, and the concept is something I am very not sure about. Would it be better as a totally separate Maven module?
- Using the assembly directly like this might also suck to maintain. 

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
