### PR TITLE
Fix echo request timeout

### DIFF
--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/impl/RpcRequestTimeoutManagerImpl.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/impl/RpcRequestTimeoutManagerImpl.java
@@ -73,8 +73,13 @@ public class RpcRequestTimeoutManagerImpl implements RpcRequestTimeoutManager {
             try {
                 RpcResponseHandler responseHandler = rpcTimeoutQueue.take();
                 if (!responseHandler.isProcessed()) {
-                    log.warn("RPC request from module: {} with RpcId:{} timedout ", responseHandler.getRpcModuleId(), responseHandler.getRpcId());
-                    responseHandlerExecutor.execute(() -> responseHandler.sendResponse(null));
+                    responseHandlerExecutor.execute(() -> {
+                        try {
+                            responseHandler.sendResponse(null);
+                        } catch (Throwable throwable) {
+                            log.error("ERROR sending RPC Request Timeout", throwable);
+                        }
+                    });
                 }
             } catch (InterruptedException e) {
                 log.info("interrupted while waiting for an element from rpcTimeoutQueue", e);

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
@@ -92,7 +92,7 @@ public class GrpcServerConfig {
             .build();
 
         // RPC timeout executor thread retrieves elements from delay queue used to timeout rpc requests.
-        ExecutorService rpcTimeoutExecutor = Executors.newSingleThreadExecutor(timerThreadFactory);
+        ExecutorService rpcTimeoutExecutor = Executors.newFixedThreadPool(3, timerThreadFactory);
 
         RpcRequestTimeoutManagerImpl result = new RpcRequestTimeoutManagerImpl();
         result.setRpcTimeoutExecutor(rpcTimeoutExecutor);

--- a/platform/core/monitor/src/main/java/org/opennms/horizon/core/monitor/MinionRpcMonitorManager.java
+++ b/platform/core/monitor/src/main/java/org/opennms/horizon/core/monitor/MinionRpcMonitorManager.java
@@ -33,6 +33,7 @@ public class MinionRpcMonitorManager implements EventListener {
     private static final String[] LABEL_NAMES = {"instance", "location"};
     private static final int MONITOR_INITIAL_DELAY = 3_000;
     private static final int MONITOR_PERIOD = 30_000;
+    private static final long ECHO_TIMEOUT = 120_000;
 
     private final CollectorRegistry collectorRegistry = new CollectorRegistry();
 
@@ -110,7 +111,7 @@ public class MinionRpcMonitorManager implements EventListener {
              .setMessage(Strings.repeat("*", DEFAULT_MESSAGE_SIZE))
              .build();
 
-         echoClient.execute(minionId, location, null, echoRequest).whenComplete((response, error) -> {
+         echoClient.execute(minionId, location, ECHO_TIMEOUT, echoRequest).whenComplete((response, error) -> {
              if (error != null) {
                  LOG.warn("ECHO REQUEST failed", error);
                  LOG.error("Minion RPC Monitor: check for minion failed: id={}", minionId);


### PR DESCRIPTION
Fix echo request timeout, Previously the timeout was always 0, the timeout logic (almost) always triggers on minion-gateway, and a single-thread executor shared with a "while (true)" loop prevents completion of the timeout response handling.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
