### PR TITLE
HS-651: Use findEventsByNodeId for events on node status page

### DIFF
--- a/ui/components.d.ts
+++ b/ui/components.d.ts
@@ -21,6 +21,7 @@ declare module '@vue/runtime-core' {
     FeatherAppBar: typeof import('@featherds/app-bar')['FeatherAppBar']
     FeatherAppLayout: typeof import('@featherds/app-layout')['FeatherAppLayout']
     FeatherAppRail: typeof import('@featherds/app-rail')['FeatherAppRail']
+    FeatherAutocomplete: typeof import('@featherds/autocomplete')['FeatherAutocomplete']
     FeatherButton: typeof import('@featherds/button')['FeatherButton']
     FeatherCheckbox: typeof import('@featherds/checkbox')['FeatherCheckbox']
     FeatherCheckboxGroup: typeof import('@featherds/checkbox')['FeatherCheckboxGroup']

--- a/ui/src/components/Events/EventsTable.vue
+++ b/ui/src/components/Events/EventsTable.vue
@@ -1,11 +1,4 @@
 <template>
-  <!-- 
-    View all events / Search (form) / Severity legend
-    Search (event text @ time)
-    Filter
-    Pagination
-    columns: ID, Severity, Time, Source Location, System-ID, Node, Node Location, Interface, Service, alarm ID 
-  -->
   <TableCard>
     <div class="header">
       <div class="title-container">
@@ -31,33 +24,23 @@
       </div>
     </div>
     <div class="container">
-      <table class="tl1 tl2 tc3 tc4 tc5 data-table" summary="Events" data-test="data-table">
+      <table class="data-table" summary="Events" data-test="data-table">
         <thead>
           <tr>
-            <th scope="col" data-test="col-id">ID</th>
-            <th scope="col" data-test="col-severity">Severity</th>
-            <th scope="col" data-test="col-time">Time</th>
-            <th scope="col" data-test="col-source-location">Source Location</th>
-            <th scope="col" data-test="col-system-id">System-ID</th>
-            <th scope="col" data-test="col-node">Node</th>
-            <th scope="col" data-test="col-node-location">Node Location</th>
-            <th scope="col" data-test="col-interface">Interface</th>
-            <th scope="col" data-test="col-service">Service</th>
-            <th scope="col" data-test="col-alarm-id">Alarm ID</th>
+            <th scope="col">ID</th>
+            <th scope="col">Time</th>
+            <th scope="col">UEI</th>
+            <th scope="col">Node Id</th>
+            <th scope="col">IP Address</th>
           </tr>
         </thead>
         <TransitionGroup name="data-table" tag="tbody">
           <tr v-for="event in nodeData.events" :key="event.id as number" data-test="data-item">
             <td>{{ event.id }}</td>
-            <td>{{ event.severity }}</td>
-            <td>{{ event.time }}</td>
-            <td>{{ event.source }}</td>
-            <td>--</td>
-            <td>{{ event.nodeLabel }}</td>
-            <td>{{ event.location }}</td>
-            <td>{{ event.ipAddress || '--' }}</td>
-            <td>--</td>
-            <td>--</td>
+            <td>{{ event.producedTime }}</td>
+            <td>{{ event.uei }}</td>
+            <td>{{ event.nodeId }}</td>
+            <td>{{ event.ipAddress }}</td>
           </tr>
         </TransitionGroup>
       </table>
@@ -91,7 +74,7 @@ const total = ref(0)
 const updatePageSize = (v: number) => { pageSize.value = v }
   
 const nodeData = computed(() => {
-  const events = nodeStatusStore.fetchedData?.listEvents?.events?.filter((event: any) => event.nodeId == route.params.id)
+  const events = nodeStatusStore.fetchedData?.events
 
   total.value = events?.length || 0
 

--- a/ui/src/graphql/Views/nodeStatusQueries.graphql
+++ b/ui/src/graphql/Views/nodeStatusQueries.graphql
@@ -1,32 +1,21 @@
-fragment ListEventsParts on Query {
-  listEvents {
-    events {
-      id
-      severity
-      time
-      source
-      nodeLabel
-      location
-      ipAddress
-      nodeId
-    }
+fragment EventsByNodeIdParts on Query {
+  events: findEventsByNodeId(id: $id) {
+    id
+    uei
+    nodeId
+    ipAddress
+    producedTime
   }
-}
-
-fragment NodeParts on Node {
-  id
-  nodeLabel
-  createTime
 }
 
 fragment NodeByIdParts on Query {
   node: findNodeById(id: $id) {
-      ...NodeParts
-    }
+    nodeLabel
+  }
 }
 
 # TODO: Add metric details when endpoints available
 query ListNodeStatus($id: Long) {
-  ...ListEventsParts
+  ...EventsByNodeIdParts
   ...NodeByIdParts
 }

--- a/ui/src/store/Queries/nodeStatusQueries.ts
+++ b/ui/src/store/Queries/nodeStatusQueries.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { useQuery } from 'villus'
-import { ListNodeStatusDocument, Node } from '@/types/graphql'
+import { Event, ListNodeStatusDocument, Node } from '@/types/graphql'
 
 export const useNodeStatusQueries = defineStore('nodeStatusQueries', () => {
   const variables = ref({})
@@ -13,11 +13,10 @@ export const useNodeStatusQueries = defineStore('nodeStatusQueries', () => {
     query: ListNodeStatusDocument,
     variables,
     cachePolicy: 'network-only'
-
   })
 
   const fetchedData = computed(() => ({
-    listEvents: data.value?.listEvents || {},
+    events: data.value?.events || [] as Event[],
     node: data.value?.node || {} as Node
   }))
 

--- a/ui/src/types/graphql.ts
+++ b/ui/src/types/graphql.ts
@@ -130,6 +130,18 @@ export type DeviceDto = {
   type?: Maybe<Scalars['String']>;
 };
 
+export type Event = {
+  __typename?: 'Event';
+  eventInfo?: Maybe<EventInfo>;
+  eventParams?: Maybe<Array<Maybe<EventParameter>>>;
+  id: Scalars['Int'];
+  ipAddress?: Maybe<Scalars['String']>;
+  nodeId: Scalars['Int'];
+  producedTime: Scalars['Long'];
+  tenantId?: Maybe<Scalars['String']>;
+  uei?: Maybe<Scalars['String']>;
+};
+
 export type EventCollectionDto = {
   __typename?: 'EventCollectionDTO';
   events?: Maybe<Array<Maybe<EventDto>>>;
@@ -212,6 +224,19 @@ export type EventDtoInput = {
   uei?: InputMaybe<Scalars['String']>;
 };
 
+export type EventInfo = {
+  __typename?: 'EventInfo';
+  snmp?: Maybe<SnmpInfo>;
+};
+
+export type EventParameter = {
+  __typename?: 'EventParameter';
+  encoding?: Maybe<Scalars['String']>;
+  name?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  value?: Maybe<Scalars['String']>;
+};
+
 export type EventParameterDto = {
   __typename?: 'EventParameterDTO';
   name?: Maybe<Scalars['String']>;
@@ -223,6 +248,14 @@ export type EventParameterDtoInput = {
   name?: InputMaybe<Scalars['String']>;
   type?: InputMaybe<Scalars['String']>;
   value?: InputMaybe<Scalars['String']>;
+};
+
+export type IpInterface = {
+  __typename?: 'IpInterface';
+  id: Scalars['Long'];
+  ipAddress?: Maybe<Scalars['String']>;
+  nodeId: Scalars['Long'];
+  tenantId?: Maybe<Scalars['String']>;
 };
 
 export type Location = {
@@ -258,6 +291,7 @@ export type Minion = {
   id: Scalars['Long'];
   label?: Maybe<Scalars['String']>;
   lastCheckedTime: Scalars['Long'];
+  location?: Maybe<Location>;
   locationId: Scalars['Long'];
   systemId?: Maybe<Scalars['String']>;
   tenantId?: Maybe<Scalars['String']>;
@@ -329,6 +363,8 @@ export type Node = {
   __typename?: 'Node';
   createTime: Scalars['Long'];
   id: Scalars['Long'];
+  ipInterfaces?: Maybe<Array<Maybe<IpInterface>>>;
+  location?: Maybe<Location>;
   monitoringLocationId: Scalars['Long'];
   nodeLabel?: Maybe<Scalars['String']>;
   tenantId?: Maybe<Scalars['String']>;
@@ -348,9 +384,11 @@ export type PagerDutyConfigDtoInput = {
 export type Query = {
   __typename?: 'Query';
   deviceById?: Maybe<DeviceDto>;
+  findAllEvents?: Maybe<Array<Maybe<Event>>>;
   findAllLocations?: Maybe<Array<Maybe<Location>>>;
   findAllMinions?: Maybe<Array<Maybe<Minion>>>;
   findAllNodes?: Maybe<Array<Maybe<Node>>>;
+  findEventsByNodeId?: Maybe<Array<Maybe<Event>>>;
   findLocationById?: Maybe<Location>;
   findMinionById?: Maybe<Minion>;
   findNodeById?: Maybe<Node>;
@@ -369,6 +407,12 @@ export type Query = {
 /** Query root */
 export type QueryDeviceByIdArgs = {
   id?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Query root */
+export type QueryFindEventsByNodeIdArgs = {
+  id?: InputMaybe<Scalars['Long']>;
 };
 
 
@@ -424,6 +468,16 @@ export type ServiceTypeDto = {
 export type ServiceTypeDtoInput = {
   id?: InputMaybe<Scalars['Int']>;
   name?: InputMaybe<Scalars['String']>;
+};
+
+export type SnmpInfo = {
+  __typename?: 'SnmpInfo';
+  community?: Maybe<Scalars['String']>;
+  generic: Scalars['Int'];
+  id?: Maybe<Scalars['String']>;
+  specific: Scalars['Int'];
+  trapOid?: Maybe<Scalars['String']>;
+  version?: Maybe<Scalars['String']>;
 };
 
 export type TsData = {
@@ -571,18 +625,16 @@ export type NodesForMapQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type NodesForMapQuery = { __typename?: 'Query', findAllNodes?: Array<{ __typename?: 'Node', id: any, nodeLabel?: string }> };
 
-export type ListEventsPartsFragment = { __typename?: 'Query', listEvents?: { __typename?: 'EventCollectionDTO', events?: Array<{ __typename?: 'EventDTO', id?: number, severity?: string, time?: any, source?: string, nodeLabel?: string, location?: string, ipAddress?: string, nodeId?: number }> } };
+export type EventsByNodeIdPartsFragment = { __typename?: 'Query', events?: Array<{ __typename?: 'Event', id: number, uei?: string, nodeId: number, ipAddress?: string, producedTime: any }> };
 
-export type NodePartsFragment = { __typename?: 'Node', id: any, nodeLabel?: string, createTime: any };
-
-export type NodeByIdPartsFragment = { __typename?: 'Query', node?: { __typename?: 'Node', id: any, nodeLabel?: string, createTime: any } };
+export type NodeByIdPartsFragment = { __typename?: 'Query', node?: { __typename?: 'Node', nodeLabel?: string } };
 
 export type ListNodeStatusQueryVariables = Exact<{
   id?: InputMaybe<Scalars['Long']>;
 }>;
 
 
-export type ListNodeStatusQuery = { __typename?: 'Query', listEvents?: { __typename?: 'EventCollectionDTO', events?: Array<{ __typename?: 'EventDTO', id?: number, severity?: string, time?: any, source?: string, nodeLabel?: string, location?: string, ipAddress?: string, nodeId?: number }> }, node?: { __typename?: 'Node', id: any, nodeLabel?: string, createTime: any } };
+export type ListNodeStatusQuery = { __typename?: 'Query', events?: Array<{ __typename?: 'Event', id: number, uei?: string, nodeId: number, ipAddress?: string, producedTime: any }>, node?: { __typename?: 'Node', nodeLabel?: string } };
 
 export const ChartPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ChartParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"TimeSeriesQueryResult"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"data"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"result"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metric"}},{"kind":"Field","name":{"kind":"Name","value":"values"}}]}}]}}]}}]} as unknown as DocumentNode<ChartPartsFragment, unknown>;
 export const ChartTimeSeriesMetricFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ChartTimeSeriesMetric"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"metric"},"name":{"kind":"Name","value":"metric"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"name"},"value":{"kind":"Variable","name":{"kind":"Name","value":"name"}}},{"kind":"Argument","name":{"kind":"Name","value":"labels"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"monitor"},"value":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"timeRange"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}}},{"kind":"Argument","name":{"kind":"Name","value":"timeRangeUnit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ChartParts"}}]}}]}}]} as unknown as DocumentNode<ChartTimeSeriesMetricFragment, unknown>;
@@ -595,9 +647,8 @@ export const MinionLatencyPartsFragmentDoc = {"kind":"Document","definitions":[{
 export const NodeTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"tenantId"}},{"kind":"Field","name":{"kind":"Name","value":"createTime"}},{"kind":"Field","name":{"kind":"Name","value":"monitoringLocationId"}}]}}]}}]} as unknown as DocumentNode<NodeTablePartsFragment, unknown>;
 export const MinionsTablePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"MinionsTableParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listMinions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"minions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"lastUpdated"}}]}}]}}]}}]} as unknown as DocumentNode<MinionsTablePartsFragment, unknown>;
 export const LocationsPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"LocationsParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listLocations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"locations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"locationName"}}]}}]}}]}}]} as unknown as DocumentNode<LocationsPartsFragment, unknown>;
-export const ListEventsPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"ListEventsParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listEvents"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"events"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"severity"}},{"kind":"Field","name":{"kind":"Name","value":"time"}},{"kind":"Field","name":{"kind":"Name","value":"source"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"location"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}}]}}]}}]}}]} as unknown as DocumentNode<ListEventsPartsFragment, unknown>;
-export const NodePartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Node"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}},{"kind":"Field","name":{"kind":"Name","value":"createTime"}}]}}]} as unknown as DocumentNode<NodePartsFragment, unknown>;
-export const NodeByIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeByIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"node"},"name":{"kind":"Name","value":"findNodeById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeParts"}}]}}]}}]} as unknown as DocumentNode<NodeByIdPartsFragment, unknown>;
+export const EventsByNodeIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"EventsByNodeIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"events"},"name":{"kind":"Name","value":"findEventsByNodeId"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"uei"}},{"kind":"Field","name":{"kind":"Name","value":"nodeId"}},{"kind":"Field","name":{"kind":"Name","value":"ipAddress"}},{"kind":"Field","name":{"kind":"Name","value":"producedTime"}}]}}]}}]} as unknown as DocumentNode<EventsByNodeIdPartsFragment, unknown>;
+export const NodeByIdPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"NodeByIdParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"Query"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"node"},"name":{"kind":"Name","value":"findNodeById"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}}]}}]}}]} as unknown as DocumentNode<NodeByIdPartsFragment, unknown>;
 export const AlarmsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"Alarms"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"listAlarms"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"alarms"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"severity"}},{"kind":"Field","name":{"kind":"Name","value":"lastEventTime"}}]}}]}}]}}]} as unknown as DocumentNode<AlarmsQuery, AlarmsQueryVariables>;
 export const ClearAlarmDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ClearAlarm"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ackDTO"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AlarmAckDTOInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"clearAlarm"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}},{"kind":"Argument","name":{"kind":"Name","value":"ackDTO"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ackDTO"}}}]}]}}]} as unknown as DocumentNode<ClearAlarmMutation, ClearAlarmMutationVariables>;
 export const CreateEventDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateEvent"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"event"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EventDTOInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createEvent"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"event"},"value":{"kind":"Variable","name":{"kind":"Name","value":"event"}}}]}]}}]} as unknown as DocumentNode<CreateEventMutation, CreateEventMutationVariables>;
@@ -611,4 +662,4 @@ export const ListMinionsAndDevicesForTablesDocument = {"kind":"Document","defini
 export const GetMetricDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMetric"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"metric"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"TimeSeriesMetric"}}]}},...TimeSeriesMetricFragmentDoc.definitions,...MetricPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetMetricQuery, GetMetricQueryVariables>;
 export const GetTimeSeriesMetricDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetTimeSeriesMetric"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"name"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"monitor"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRange"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"timeRangeUnit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"TimeRangeUnit"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ChartTimeSeriesMetric"}}]}},...ChartTimeSeriesMetricFragmentDoc.definitions,...ChartPartsFragmentDoc.definitions]} as unknown as DocumentNode<GetTimeSeriesMetricQuery, GetTimeSeriesMetricQueryVariables>;
 export const NodesForMapDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"NodesForMap"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findAllNodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"nodeLabel"}}]}}]}}]} as unknown as DocumentNode<NodesForMapQuery, NodesForMapQueryVariables>;
-export const ListNodeStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListNodeStatus"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ListEventsParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeByIdParts"}}]}},...ListEventsPartsFragmentDoc.definitions,...NodeByIdPartsFragmentDoc.definitions,...NodePartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodeStatusQuery, ListNodeStatusQueryVariables>;
+export const ListNodeStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ListNodeStatus"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Long"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"EventsByNodeIdParts"}},{"kind":"FragmentSpread","name":{"kind":"Name","value":"NodeByIdParts"}}]}},...EventsByNodeIdPartsFragmentDoc.definitions,...NodeByIdPartsFragmentDoc.definitions]} as unknown as DocumentNode<ListNodeStatusQuery, ListNodeStatusQueryVariables>;

--- a/ui/tests/fixture/events.ts
+++ b/ui/tests/fixture/events.ts
@@ -1,16 +1,13 @@
-import { EventDto, EventCollectionDto } from '@/types/graphql'
+import { Event } from '@/types/graphql'
 
-const mockData: EventDto = {
-  'id': 2,
-  'severity': 'WARNING',
-  'time': '2022-09-20T09:25:44Z',
-  'source': 'Device-Rest-Service',
-  'nodeLabel': 'Unknown',
-  'location': 'Default',
-  'ipAddress': '',
-  'nodeId': 1
+const mockData: Event = {
+  id: 2,
+  uei: 'uei',
+  nodeId: 1,
+  ipAddress: '127.0.0.1',
+  producedTime: '2022-09-20T09:25:44Z',
 }
-const eventsFixture = (props: Partial<EventDto> = {}): EventCollectionDto => ({
+const eventsFixture = (props: Partial<Event> = {}) => ({
   events: [
     { ...mockData, ...props }
   ]

--- a/ui/tests/store/Queries/nodeStatusQueries.test.ts
+++ b/ui/tests/store/Queries/nodeStatusQueries.test.ts
@@ -17,7 +17,7 @@ describe('Events queries', () => {
       useQuery: vi.fn().mockImplementation(() => ({
         data: { 
           value: { 
-            listEvents: eventsFixture(),
+            events: eventsFixture(),
             node: nodeFixture()
           }}
       }))
@@ -27,7 +27,7 @@ describe('Events queries', () => {
     nodeStatusQueries.setNodeId(2)
 
     const expectedFetchedData = {
-      listEvents: eventsFixture(),
+      events: eventsFixture(),
       node: nodeFixture()
     }
     expect(nodeStatusQueries.fetchedData).toStrictEqual(expectedFetchedData)


### PR DESCRIPTION
## Description
Previously calling for all events and then filtering by nodeId on the frontend.
Changed to use the new findEventsByNodeId endpoint.
The designs for this page are yet to be completed, so for now we show just the basic event properties in the table.

## Jira link(s)
- https://issues.opennms.org/browse/HS-651

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
