### PR TITLE
disable ignite notifier

### DIFF
--- a/charts/opennms/templates/opennms/minion/minion-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-deployment.yaml
@@ -67,6 +67,8 @@ spec:
               value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y" # FIXME: Permanent debug port, enable only for dev mode
             - name: LOCATION
               value: "Default"
+            - name: IGNITE_UPDATE_NOTIFIER # Disable Ignite version lookups
+              value: "false"
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.Minion.Port }}

--- a/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
+++ b/charts/opennms/templates/opennms/minion/minion-gateway-deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"  # FIXME: Permanent debug port, enable only for dev mode
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: "{{ .Values.Kafka.ServiceName }}:{{ .Values.Kafka.Port }}"
+            - name: IGNITE_UPDATE_NOTIFIER # Disable Ignite version lookups
+              value: "false"
           ports:
             - name: http
               containerPort: {{ .Values.OpenNMS.MinionGateway.Port }}

--- a/minion/docker-assembly/src/main/docker/app/Dockerfile
+++ b/minion/docker-assembly/src/main/docker/app/Dockerfile
@@ -65,14 +65,9 @@ CMD [ "daemon" ]
 STOPSIGNAL SIGTERM
 
 ### Runtime information and not relevant at build time
-ENV MINION_ID="00000000-0000-0000-0000-deadbeef0001" \
-    MINION_LOCATION="MINION" \
-    OPENNMS_BROKER_URL="tcp://127.0.0.1:61616" \
-    OPENNMS_HTTP_URL="http://127.0.0.1:8980/opennms" \
-    OPENNMS_HTTP_USER="minion" \
-    OPENNMS_HTTP_PASS="minion" \
-    OPENNMS_BROKER_USER="minion" \
-    OPENNMS_BROKER_PASS="minion"
+ENV IGNITE_UPDATE_NOTIFIER="false" \
+    MINION_ID="00000000-0000-0000-0000-deadbeef0001" \
+    MINION_LOCATION="MINION"
 
 ##------------------------------------------------------------------------------
 ## EXPOSED PORTS


### PR DESCRIPTION
Disable Ignite version lookups at runtime

Working towards reducing the number of external calls made by the services