### PR TITLE
add Cortex to the stack

### DIFF
--- a/charts/opennms/templates/opennms/api/api-deployment.yaml
+++ b/charts/opennms/templates/opennms/api/api-deployment.yaml
@@ -52,7 +52,7 @@ spec:
             - name: HORIZON_STREAM_CORE_URL
               value: "http://{{ .Values.OpenNMS.Core.ServiceName }}:{{ .Values.OpenNMS.Core.HttpPort }}"
             - name: TSDB_URL
-              value: "http://{{ .Values.Prometheus.Server.ServiceName }}:{{ .Values.Prometheus.Server.Port }}/api/v1/query"
+              value: "http://{{ .Values.Cortex.ServiceName }}:{{ .Values.Cortex.Port }}/prometheus/api/v1/query"
             - name: SPRING_WEBFLUX_BASE_PATH
               value: /api
             - name: GRAPHQL_SPQR_GUI_TARGET_ENDPOINT

--- a/charts/opennms/templates/prometheus/cortex-configmap.yaml
+++ b/charts/opennms/templates/prometheus/cortex-configmap.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ .Values.Cortex.ServiceName }}
+  name: cortex-config-map
+  namespace: {{ .Release.Namespace }}
+data:
+  cortex.yml: |
+    # Configuration for running Cortex in single-process mode.
+    # This should not be used in production.  It is only for getting started
+    # and development.
+    
+    # Disable the requirement that every request to Cortex has a
+    # X-Scope-OrgID header. `fake` will be substituted in instead.
+    auth_enabled: false
+        
+    server:
+      http_listen_port: {{ .Values.Cortex.Port }}
+
+      # Configure the server to allow messages up to 100MB.
+      grpc_server_max_recv_msg_size: 104857600
+      grpc_server_max_send_msg_size: 104857600
+      grpc_server_max_concurrent_streams: 1000
+    
+    distributor:
+      shard_by_all_labels: true
+      pool:
+        health_check_ingesters: true
+    
+    ingester_client:
+      grpc_client_config:
+        # Configure the client to allow messages up to 100MB.
+        max_recv_msg_size: 104857600
+        max_send_msg_size: 104857600
+        grpc_compression: gzip
+
+    ingester:
+      lifecycler:
+        # The address to advertise for this ingester.  Will be autodiscovered by
+        # looking up address on eth0 or en0; can be specified if this fails.
+        # address: 127.0.0.1
+    
+        # We want to start immediately and flush on shutdown.
+        min_ready_duration: 0s
+        final_sleep: 0s
+        num_tokens: 512
+    
+        # Use an in memory ring store, so we don't need to launch a Consul.
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+
+    blocks_storage:
+      tsdb:
+        dir: /tmp/cortex/tsdb
+
+      bucket_store:
+        sync_dir: /tmp/cortex/tsdb-sync
+
+      backend: filesystem
+      filesystem:
+        dir: ./data/tsdb
+
+    compactor:
+      data_dir: /tmp/cortex/compactor
+      sharding_ring:
+        kvstore:
+          store: inmemory
+
+    frontend_worker:
+      match_max_concurrent: true
+
+    ruler:
+      enable_api: true
+
+    ruler_storage:
+      backend: local
+      local:
+        directory: /tmp/cortex/rules

--- a/charts/opennms/templates/prometheus/cortex-deployment.yaml
+++ b/charts/opennms/templates/prometheus/cortex-deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.Cortex.ServiceName }}
+  labels:
+    app: {{ .Values.Cortex.ServiceName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Values.Cortex.ServiceName }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.Cortex.ServiceName }}
+    spec:
+      {{- if .Values.NodeRestrictions.Enabled }}
+      nodeSelector:
+        {{ .Values.NodeRestrictions.Key }}: {{ .Values.NodeRestrictions.Value }}
+      tolerations:
+        - effect: "NoSchedule"
+          key: "{{ .Values.NodeRestrictions.Key }}"
+          operator: "Equal"
+          value: {{ .Values.NodeRestrictions.Value }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "{{ .Values.NodeRestrictions.Key }}"
+                    operator: In
+                    values:
+                      - {{ .Values.NodeRestrictions.Value }}
+      {{- end }}
+      volumes:
+        - name: cortex-config-volume
+          configMap:
+            name: cortex-config-map
+      containers:
+        - name: {{ .Values.Cortex.ServiceName }}
+          image: {{ .Values.Cortex.Image }}
+          args: ["-config.file=/etc/cortex.yml"]
+          ports:
+            - containerPort: {{ .Values.Cortex.Port }}
+          resources:
+            limits:
+              cpu: {{ .Values.Cortex.Resources.Limits.Cpu }}
+              memory: {{ .Values.Cortex.Resources.Limits.Memory }}
+            requests:
+              cpu: {{ .Values.Cortex.Resources.Requests.Cpu }}
+              memory: {{ .Values.Cortex.Resources.Requests.Memory }}
+          volumeMounts:
+            - name: cortex-config-volume
+              mountPath: "/etc/cortex.yml"
+              subPath: "cortex.yml"

--- a/charts/opennms/templates/prometheus/cortex-service.yaml
+++ b/charts/opennms/templates/prometheus/cortex-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ .Values.Cortex.ServiceName }}
+  name: {{ .Values.Cortex.ServiceName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.Cortex.Port }}
+      protocol: TCP
+      name: cortex-http
+  selector:
+    app: {{ .Values.Cortex.ServiceName }}

--- a/charts/opennms/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/opennms/templates/prometheus/prometheus-configmap.yaml
@@ -21,3 +21,5 @@ data:
           - targets: ['{{ .Values.Prometheus.PushGateway.ServiceName }}:{{ .Values.Prometheus.PushGateway.Port }}']
             labels:
               pushgateway_instance: horizon-core-pushgateway
+    remote_write:
+      - url: http://{{ .Values.Cortex.ServiceName }}:{{ .Values.Cortex.Port }}/api/v1/push

--- a/charts/opennms/values.yaml
+++ b/charts/opennms/values.yaml
@@ -208,6 +208,17 @@ Grafana:
     Requests:
       Cpu: 100m
       Memory: 100Mi
+Cortex:
+  ServiceName: cortex
+  Port: 9000
+  Image: cortexproject/cortex:v1.14.0
+  Resources:
+    Limits:
+      Cpu: "1"
+      Memory: 512Mi
+    Requests:
+      Cpu: 100m
+      Memory: 100Mi
 Prometheus:
   Enabled: true
   Server:


### PR DESCRIPTION
Add Cortex to the stack and integrate it into the write/read paths:
 * add the Cortex service
 * push metrics from Prometheus to Cortex using the Remote Write API
 * point the BFF to the Read API on Cortex

This keeps everything working, and allows us to begin writing directly to Cortex. We can then remove Prometheus and the PushGateway once complete.