### PR TITLE
HS-611: Support tenant id in inventory for tasksets

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -161,7 +161,7 @@ jib_project(
     'opennms/horizon-stream-alarm',
     'alarm',
     'opennms-alarm',
-    port_forwards=['31080:9090', '31050:5005', '31065:6565',  '31000:8080'],
+    port_forwards=['32080:9090', '32050:5005', '32065:6565',  '32000:8080'],
 )
 
 ### Metrics Processor ###

--- a/build-tools/basic/run-port-forwards.sh
+++ b/build-tools/basic/run-port-forwards.sh
@@ -11,8 +11,8 @@ stop ()
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/ingress-nginx-controller 8123:80 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-inventory 29080:8080 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-inventory 29050:5005 &
-kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-alarm 29080:8080 &
-kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-alarm 29050:5005 &
+kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-alarm 32080:8080 &
+kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-alarm 32050:5005 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-notifications 15080:8080 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-notifications 15050:5005 &
 kubectl --context kind-kind port-forward --pod-running-timeout 1s --namespace default deployment/opennms-core 11080:8181 &

--- a/charts/opennms/values.yaml
+++ b/charts/opennms/values.yaml
@@ -71,10 +71,10 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "1"
-        Memory: 2050M
+        Memory: 500Mi
       Requests:
-        Cpu: "1"
-        Memory: 512Mi
+        Cpu: 100m
+        Memory: 250Mi
   MinionGateway:
     ServiceName: opennms-minion-gateway
     Image: opennms/horizon-stream-minion-gateway
@@ -87,10 +87,10 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "1"
-        Memory: 2050M
+        Memory: 500Mi
       Requests:
-        Cpu: "1"
-        Memory: 512Mi
+        Cpu: 100m
+        Memory: 250Mi
   MinionGatewayGrpcProxy:
     ServiceName: opennms-minion-gateway-grpc-proxy
     Image: opennms/horizon-stream-minion-gateway-grpc-proxy
@@ -100,10 +100,10 @@ OpenNMS:
     Resources:
       Limits:
         Cpu: "1"
-        Memory: 2050M
+        Memory: 500Mi
       Requests:
-        Cpu: "1"
-        Memory: 512Mi
+        Cpu: 100m
+        Memory: 250Mi
   Inventory:
     ServiceName: opennms-inventory
     Image: opennms/horizon-stream-inventory

--- a/inventory/src/main/java/org/opennms/horizon/inventory/grpc/InventoryServerInterceptor.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/grpc/InventoryServerInterceptor.java
@@ -38,7 +38,6 @@ import org.keycloak.adapters.rotation.AdapterTokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.util.TokenUtil;
-import org.opennms.horizon.inventory.Constants;
 
 import io.grpc.Context;
 import io.grpc.Contexts;
@@ -49,6 +48,7 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.opennms.horizon.inventory.Constants;
 
 @RequiredArgsConstructor
 @Slf4j

--- a/inventory/src/main/java/org/opennms/horizon/inventory/repository/IpInterfaceRepository.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/repository/IpInterfaceRepository.java
@@ -42,18 +42,14 @@ import java.util.Optional;
 public interface IpInterfaceRepository extends JpaRepository<IpInterface, Long> {
     List<IpInterface> findByTenantId(String tenantId);
 
-    @Query("select ip from IpInterface ip" +
-        " inner join Node n on ip.nodeId = n.id" +
-        " inner join MonitoringLocation ml on n.monitoringLocationId = ml.id" +
-        " where ip.ipAddress = ?1 and ml.location = ?2 and ip.tenantId = ?3")
-   Optional<IpInterface> findByIpAddressAndLocationAndTenantId(Inet ipAddress, String location, String tenantId);
-
     @Query("SELECT ip " +
         "FROM IpInterface ip " +
         "WHERE ip.ipAddress = :ipAddress " +
-        "AND ip.node.monitoringLocation.location = :location ")
-    Optional<IpInterface> findByIpAddressAndLocation(@Param("ipAddress") Inet ipAddress,
-                                                     @Param("location") String location);
+        "AND ip.node.monitoringLocation.location = :location " +
+        "AND ip.tenantId = :tenantId ")
+    Optional<IpInterface> findByIpAddressAndLocationAndTenantId(@Param("ipAddress") Inet ipAddress,
+                                                                @Param("location") String location,
+                                                                @Param("tenantId") String tenantId);
 
     List<IpInterface> findByNodeId(long nodeId);
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
@@ -30,6 +30,7 @@ package org.opennms.horizon.inventory.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.Any;
 import lombok.RequiredArgsConstructor;
+import org.opennms.horizon.inventory.dto.MonitoringLocation;
 import org.opennms.horizon.inventory.dto.MonitoringLocationDTO;
 import org.opennms.horizon.inventory.service.taskset.manager.TaskSetManager;
 import org.opennms.horizon.inventory.service.trapconfig.TrapConfigBean;
@@ -37,6 +38,7 @@ import org.opennms.sink.traps.contract.ListenerConfig;
 import org.opennms.sink.traps.contract.SnmpV3User;
 import org.opennms.sink.traps.contract.TrapConfig;
 import org.opennms.taskset.contract.TaskDefinition;
+import org.opennms.taskset.contract.TaskSet;
 import org.opennms.taskset.contract.TaskType;
 import org.opennms.taskset.service.api.TaskSetPublisher;
 import org.slf4j.Logger;
@@ -110,8 +112,10 @@ public class TrapConfigService {
             .setConfiguration(Any.pack(trapConfig))
             .build();
 
-        taskSetManager.addTaskSet(location, taskDefinition);
-        taskSetPublisher.publishTaskSet(tenantId, location, taskSetManager.getTaskSet(location));
+        taskSetManager.addTaskSet(tenantId, location, taskDefinition);
+
+        TaskSet taskSet = taskSetManager.getTaskSet(location, location);
+        taskSetPublisher.publishTaskSet(tenantId, location, taskSet);
     }
 
     private TrapConfigBean readTrapConfig() {

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/TrapConfigService.java
@@ -114,7 +114,7 @@ public class TrapConfigService {
 
         taskSetManager.addTaskSet(tenantId, location, taskDefinition);
 
-        TaskSet taskSet = taskSetManager.getTaskSet(location, location);
+        TaskSet taskSet = taskSetManager.getTaskSet(tenantId, location);
         taskSetPublisher.publishTaskSet(tenantId, location, taskSet);
     }
 

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/DetectorTaskSetService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/DetectorTaskSetService.java
@@ -80,6 +80,8 @@ public class DetectorTaskSetService {
     }
 
     private void addDetectorTask(Node node, IpInterface ipInterface, MonitorType monitorType) {
+        String tenantId = node.getTenantId();
+
         String ipAddress = ipInterface.getIpAddress().getAddress();
         MonitoringLocation monitoringLocation = node.getMonitoringLocation();
         String location = monitoringLocation.getLocation();
@@ -101,7 +103,7 @@ public class DetectorTaskSetService {
                         .setRetries(Constants.Icmp.DEFAULT_RETRIES)
                         .build());
 
-                taskSetManagerUtil.addTask(location, ipAddress, name,
+                taskSetManagerUtil.addTask(tenantId, location, ipAddress, name,
                     TaskType.DETECTOR, pluginName, configuration, node.getId());
                 break;
             }
@@ -113,7 +115,8 @@ public class DetectorTaskSetService {
                         .setRetries(Constants.Snmp.DEFAULT_RETRIES)
                         .build());
 
-                taskSetManagerUtil.addTask(location, ipAddress, name, TaskType.DETECTOR, pluginName, configuration, node.getId());
+                taskSetManagerUtil.addTask(tenantId, location, ipAddress, name,
+                    TaskType.DETECTOR, pluginName, configuration, node.getId());
                 break;
             }
             case UNRECOGNIZED: {
@@ -132,7 +135,7 @@ public class DetectorTaskSetService {
 
         MonitoringLocation monitoringLocation = node.getMonitoringLocation();
         String location = monitoringLocation.getLocation();
-        TaskSet taskSet = taskSetManager.getTaskSet(location);
+        TaskSet taskSet = taskSetManager.getTaskSet(tenantId, location);
 
         log.info("Sending task set: task-set={}; location={}; tenant-id={}", taskSet, location, tenantId);
         taskSetPublisher.publishTaskSet(tenantId, location, taskSet);

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/MonitorTaskSetService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/MonitorTaskSetService.java
@@ -52,11 +52,15 @@ public class MonitorTaskSetService {
     private final TaskSetPublisher taskSetPublisher;
 
     public void sendMonitorTask(String location, MonitorType monitorType, IpInterface ipInterface, long nodeId) {
+        String tenantId = ipInterface.getTenantId();
+
         addMonitorTask(location, monitorType, ipInterface, nodeId);
-        sendTaskSet(location);
+        sendTaskSet(tenantId, location);
     }
 
     private void addMonitorTask(String location, MonitorType monitorType, IpInterface ipInterface, long nodeId) {
+        String tenantId = ipInterface.getTenantId();
+
         String monitorTypeValue = monitorType.getValueDescriptor().getName();
         String ipAddress = ipInterface.getIpAddress().getAddress();
 
@@ -75,7 +79,7 @@ public class MonitorTaskSetService {
                         .setRetries(Constants.Icmp.DEFAULT_RETRIES)
                         .build());
 
-                taskSetManagerUtil.addTask(location, ipAddress, name,
+                taskSetManagerUtil.addTask(tenantId, location, ipAddress, name,
                     TaskType.MONITOR, pluginName, Constants.DEFAULT_SCHEDULE, nodeId, configuration);
                 break;
             }
@@ -87,7 +91,8 @@ public class MonitorTaskSetService {
                         .setRetries(Constants.Snmp.DEFAULT_RETRIES)
                         .build());
 
-                taskSetManagerUtil.addTask(location, ipAddress, name, TaskType.MONITOR, pluginName, Constants.DEFAULT_SCHEDULE, nodeId, configuration);
+                taskSetManagerUtil.addTask(tenantId, location, ipAddress, name,
+                    TaskType.MONITOR, pluginName, Constants.DEFAULT_SCHEDULE, nodeId, configuration);
                 break;
             }
             case UNRECOGNIZED: {
@@ -101,11 +106,8 @@ public class MonitorTaskSetService {
         }
     }
 
-    private void sendTaskSet(String location) {
-        String tenantId = "opennms-prime";  // TBD888: properly source the Tenant ID
-
-        TaskSet taskSet = taskSetManager.getTaskSet(location);
-
+    private void sendTaskSet(String tenantId, String location) {
+        TaskSet taskSet = taskSetManager.getTaskSet(tenantId, location);
         log.info("Sending task set: task-set={}; location={}; tenant-id={}", taskSet, location, tenantId);
         taskSetPublisher.publishTaskSet(tenantId, location, taskSet);
     }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/manager/DefaultTaskSetManager.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/manager/DefaultTaskSetManager.java
@@ -40,12 +40,14 @@ import java.util.Map;
 @Component
 public class DefaultTaskSetManager implements TaskSetManager {
 
-    private final Map<String, TaskSet> taskSetsByLocation = new HashMap<>();
+    private final Map<String, Map<String, TaskSet>> taskSetsByTenantLocation = new HashMap<>();
 
     @Override
-    public synchronized void addTaskSet(String location, TaskDefinition newTaskDefinition) {
+    public synchronized void addTaskSet(String tenantId, String location, TaskDefinition newTaskDefinition) {
+        Map<String, TaskSet> taskSetsByLocation = taskSetsByTenantLocation.computeIfAbsent(tenantId, (unusedTenantId) -> new HashMap<>());
         TaskSet existingTaskSet = taskSetsByLocation.get(location);
         TaskSet taskSet;
+
         if (existingTaskSet != null) {
             List<TaskDefinition> existingTaskDefinitions = new ArrayList<>(existingTaskSet.getTaskDefinitionList());
             existingTaskDefinitions.removeIf(task -> task.getId().equals(newTaskDefinition.getId()));
@@ -54,11 +56,18 @@ public class DefaultTaskSetManager implements TaskSetManager {
         } else {
             taskSet = TaskSet.newBuilder().addTaskDefinition(newTaskDefinition).build();
         }
+
         taskSetsByLocation.put(location, taskSet);
     }
 
     @Override
-    public synchronized TaskSet getTaskSet(String location) {
-        return taskSetsByLocation.get(location);
+    public synchronized TaskSet getTaskSet(String tenantId, String location) {
+        Map<String, TaskSet> taskSetsByLocation = taskSetsByTenantLocation.get(tenantId);
+
+        if (taskSetsByLocation != null) {
+            return taskSetsByLocation.get(location);
+        }
+
+        return null;
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/manager/TaskSetManager.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/manager/TaskSetManager.java
@@ -33,7 +33,7 @@ import org.opennms.taskset.contract.TaskSet;
 
 public interface TaskSetManager {
 
-    void addTaskSet(String location, TaskDefinition taskDefinition);
+    void addTaskSet(String tenantId, String location, TaskDefinition taskDefinition);
 
-    TaskSet getTaskSet(String location);
+    TaskSet getTaskSet(String tenantId, String location);
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/manager/TaskSetManagerUtil.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/manager/TaskSetManagerUtil.java
@@ -44,23 +44,22 @@ public class TaskSetManagerUtil {
     private final TaskSetManager taskSetManager;
     private final TaskSetIdentityUtil taskSetIdentityUtil;
 
-    public void addTask(String location, String ipAddress, String name, TaskType taskType,
+    public void addTask(String tenantId, String location, String ipAddress, String name, TaskType taskType,
                         String pluginName, String schedule, long nodeId, Any configuration) {
 
         String taskId = taskSetIdentityUtil.identityForIpTask(ipAddress, name);
-        addTaskToTaskSet(location, taskType, pluginName, schedule, configuration, taskId, nodeId);
+        addTaskToTaskSet(tenantId, location, taskType, pluginName, schedule, configuration, taskId, nodeId);
     }
 
-    public void addTask(String location, String ipAddress, String name, TaskType taskType,
+    public void addTask(String tenantId, String location, String ipAddress, String name, TaskType taskType,
                         String pluginName, Any configuration, long nodeId) {
 
         String taskId = taskSetIdentityUtil.identityForIpTask(ipAddress, name);
-        addTaskToTaskSet(location, taskType, pluginName, null, configuration, taskId, nodeId);
+        addTaskToTaskSet(tenantId, location, taskType, pluginName, null, configuration, taskId, nodeId);
     }
 
-    private void addTaskToTaskSet(String location, TaskType taskType, String pluginName, String schedule,
+    private void addTaskToTaskSet(String tenantId, String location, TaskType taskType, String pluginName, String schedule,
                                   Any configuration, String taskId, long nodeId) {
-
 
         TaskDefinition.Builder builder =
             TaskDefinition.newBuilder()
@@ -79,6 +78,6 @@ public class TaskSetManagerUtil {
 
         TaskDefinition taskDefinition = builder.build();
 
-        taskSetManager.addTaskSet(location, taskDefinition);
+        taskSetManager.addTaskSet(tenantId, location, taskDefinition);
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
@@ -46,7 +46,7 @@ public class GrpcTaskSetPublisher implements TaskSetPublisher {
     private static final Logger log = LoggerFactory.getLogger(GrpcTaskSetPublisher.class);
     private final TaskSetServiceGrpc.TaskSetServiceBlockingStub taskSetServiceStub;
 
-    private static final Metadata.Key HEADER_KEY = Metadata.Key.of("tenant-id", Metadata.ASCII_STRING_MARSHALLER);
+    private static final Metadata.Key<String> HEADER_KEY = Metadata.Key.of("tenant-id", Metadata.ASCII_STRING_MARSHALLER);
 
     @Override
     public void publishTaskSet(String tenantId, String location, TaskSet taskSet) {

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseService.java
@@ -54,15 +54,13 @@ public class DetectorResponseService {
     private final MonitoredServiceService monitoredServiceService;
     private final MonitorTaskSetService monitorTaskSetService;
 
-    public void accept(String location, DetectorResponse response) {
-        log.info("Received Detector Response = {} for location = {}", response, location);
+    public void accept(String tenantId, String location, DetectorResponse response) {
+        log.info("Received Detector Response = {} for tenant = {} and location = {}", response, tenantId, location);
 
         Inet ipAddress = new Inet(response.getIpAddress());
 
-        //todo: This should have tenantId in it, as it is possible
-        // that a different tenant is using the same location and ipAddress
         Optional<IpInterface> ipInterfaceOpt = ipInterfaceRepository
-            .findByIpAddressAndLocation(ipAddress, location);
+            .findByIpAddressAndLocationAndTenantId(ipAddress, location, tenantId);
 
         if (ipInterfaceOpt.isPresent()) {
             IpInterface ipInterface = ipInterfaceOpt.get();
@@ -71,7 +69,9 @@ public class DetectorResponseService {
                 createMonitoredService(response, ipInterface);
 
                 MonitorType monitorType = response.getMonitorType();
-                monitorTaskSetService.sendMonitorTask(location, monitorType, ipInterface, response.getNodeId());
+                long nodeId = response.getNodeId();
+
+                monitorTaskSetService.sendMonitorTask(location, monitorType, ipInterface, nodeId);
 
             } else {
                 log.info("{} not detected on ip address = {}", response.getMonitorType(), ipAddress.getAddress());

--- a/inventory/src/test/java/org/opennms/horizon/inventory/component/TaskSetResultsConsumerTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/component/TaskSetResultsConsumerTest.java
@@ -6,10 +6,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.opennms.horizon.inventory.Constants;
 import org.opennms.horizon.inventory.service.taskset.response.DetectorResponseService;
 import org.opennms.taskset.contract.DetectorResponse;
 import org.opennms.taskset.contract.TaskResult;
 import org.opennms.taskset.contract.TaskSetResults;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.Mockito.times;
 
@@ -17,6 +21,8 @@ import static org.mockito.Mockito.times;
 public class TaskSetResultsConsumerTest {
 
     private static final String TEST_LOCATION = "Default";
+    private static final String TEST_TENANT_ID = "opennms-prime";
+
     @InjectMocks
     private TaskSetResultsConsumer consumer;
 
@@ -36,9 +42,12 @@ public class TaskSetResultsConsumerTest {
         TaskSetResults results = TaskSetResults.newBuilder()
             .addResults(taskResult).build();
 
-        consumer.receiveMessage(results.toByteArray());
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(Constants.TENANT_ID_KEY, TEST_TENANT_ID.getBytes());
+
+        consumer.receiveMessage(results.toByteArray(), headers);
 
         Mockito.verify(service, times(1))
-            .accept(TEST_LOCATION, response);
+            .accept(TEST_TENANT_ID, TEST_LOCATION, response);
     }
 }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseServiceIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseServiceIntTest.java
@@ -95,7 +95,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
             .setDetected(true).setIpAddress(TEST_IP_ADDRESS)
             .setMonitorType(MonitorType.SNMP).build();
 
-        service.accept(TEST_LOCATION, response);
+        service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
 
         List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
         assertEquals(1, monitoredServiceTypes.size());
@@ -131,7 +131,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
         int numberOfCalls = 2;
 
         for (int index = 0; index < numberOfCalls; index++) {
-            service.accept(TEST_LOCATION, response);
+            service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
         }
 
         List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
@@ -165,7 +165,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
             .setDetected(false).setIpAddress(TEST_IP_ADDRESS)
             .setMonitorType(MonitorType.SNMP).build();
 
-        service.accept(TEST_LOCATION, response);
+        service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
 
         List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();
         assertEquals(0, monitoredServiceTypes.size());
@@ -193,7 +193,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
             DetectorResponse response = builder
                 .setMonitorType(monitorTypes[index]).build();
 
-            service.accept(TEST_LOCATION, response);
+            service.accept(TEST_TENANT_ID, TEST_LOCATION, response);
         }
 
         List<MonitoredServiceType> monitoredServiceTypes = monitoredServiceTypeRepository.findAll();

--- a/platform/traps/src/main/java/org/opennms/horizon/traps/consumer/TrapSinkConsumer.java
+++ b/platform/traps/src/main/java/org/opennms/horizon/traps/consumer/TrapSinkConsumer.java
@@ -170,8 +170,8 @@ public class TrapSinkConsumer implements  EventListener, Processor {
             .setConfiguration(Any.pack(trapConfig))
             .build();
 
-        taskSetManager.addTaskSet("opennms-prime", location, taskDefinition);
-        taskSetPublisher.publishTaskSet(tenantId, location, taskSetManager.getTaskSet("opennms-prime", location));
+        taskSetManager.addTaskSet(tenantId, location, taskDefinition);
+        taskSetPublisher.publishTaskSet(tenantId, location, taskSetManager.getTaskSet(tenantId, location));
 
     }
 


### PR DESCRIPTION
## Description
HS-611: Support tenant id in inventory for tasksets

- updating port forward in tilt for alarm service again due to the conflict with the new grpc proxy service
- i had to reduce the memory of some services as i ran into problems with memory on startup when the new grpc proxy service was added (please review the values)
- tested this by passing tenant id through grpc header and seeing it in Minion Gateway interceptor through debug breakpoint, then seeing the tenant id coming through in the kafka consumer.

## Jira link(s)
- https://issues.opennms.org/browse/HS-611

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [x] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
