### PR TITLE
HS-661 Allow customization of grpc contact point for minion by env vars

### DIFF
--- a/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
+++ b/minion/assembly/src/main/resources/etc/org.opennms.core.ipc.grpc.client.cfg
@@ -1,0 +1,4 @@
+host=${env:MINION_GATEWAY_HOST:-minion-gateway}
+port=${env:MINION_GATEWAY_PORT:-8990}
+tls.enabled=${env:MINION_GATEWAY_TLS:-false}
+max.message.size=${env:MINION_GATEWAY_MAX_MESSAGE_SIZE:-104857600}

--- a/minion/docker-assembly/src/main/docker/app/Dockerfile
+++ b/minion/docker-assembly/src/main/docker/app/Dockerfile
@@ -67,7 +67,11 @@ STOPSIGNAL SIGTERM
 ### Runtime information and not relevant at build time
 ENV IGNITE_UPDATE_NOTIFIER="false" \
     MINION_ID="00000000-0000-0000-0000-deadbeef0001" \
-    MINION_LOCATION="MINION"
+    MINION_LOCATION="MINION" \
+    MINION_GATEWAY_HOST="minion-gateway" \
+    MINION_GATEWAY_PORT="8990" \
+    MINION_GATEWAY_TLS="false"
+
 
 ##------------------------------------------------------------------------------
 ## EXPOSED PORTS


### PR DESCRIPTION
## Description
Possibility to control grpc connection via env vars.

## Jira link(s)
- https://issues.opennms.org/browse/HS-661

## Flagged for review

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
