### PR TITLE
HS-643: Add link to node status page, inventory card mods

### DIFF
--- a/ui/src/components/Common/Icon.vue
+++ b/ui/src/components/Common/Icon.vue
@@ -1,5 +1,15 @@
 <template>
-  <FeatherIcon :icon="icon.image" :title="icon.title" :viewBox="setViewBox(icon.image)" />
+  <FeatherTooltip
+    :title="icon.tooltip || ''"
+    v-slot="{ attrs, on }"
+  >
+    <FeatherIcon
+      v-bind="icon.tooltip ? attrs : null" 
+      v-on="on" :icon="icon.image" 
+      :title="icon.title" 
+      :viewBox="setViewBox(icon.image)" 
+    />
+  </FeatherTooltip>
 </template>
 
 <script lang="ts" setup>

--- a/ui/src/components/Inventory/DetectedNodesTabContent.vue
+++ b/ui/src/components/Inventory/DetectedNodesTabContent.vue
@@ -43,7 +43,7 @@ ul {
   flex-flow: row wrap;
   gap: 1rem;
   > li {
-    padding: var(variables.$spacing-l) var(variables.$spacing-xxl) var(variables.$spacing-l) var(variables.$spacing-xxl);
+    padding: var(variables.$spacing-l) var(variables.$spacing-xxl);
     border: 1px solid var(variables.$secondary-text-on-surface); 
     border-radius: 10px;
     border-left: 10px solid var(variables.$secondary-text-on-surface); // TODO set color dynamically to the node's status

--- a/ui/src/components/Inventory/DetectedNodesTabContent.vue
+++ b/ui/src/components/Inventory/DetectedNodesTabContent.vue
@@ -43,7 +43,7 @@ ul {
   flex-flow: row wrap;
   gap: 1rem;
   > li {
-    padding: var(variables.$spacing-l);
+    padding: var(variables.$spacing-l) var(variables.$spacing-xxl) var(variables.$spacing-l) var(variables.$spacing-xxl);
     border: 1px solid var(variables.$secondary-text-on-surface); 
     border-radius: 10px;
     border-left: 10px solid var(variables.$secondary-text-on-surface); // TODO set color dynamically to the node's status

--- a/ui/src/components/Inventory/IconActionList.vue
+++ b/ui/src/components/Inventory/IconActionList.vue
@@ -49,7 +49,7 @@ const pieChartIcon: IIcon = {
 
 const onWarning = () => {
   router.push({ 
-    name: 'Nodes', 
+    name: 'Node', 
     params: { id: props.node.id } 
   })
 }

--- a/ui/src/components/Inventory/IconActionList.vue
+++ b/ui/src/components/Inventory/IconActionList.vue
@@ -1,10 +1,10 @@
 <template>
   <ul class="icon-action-list">
-    <li @click="onBubbleChart" data-test="bubble-chart"><Icon :icon="bubbleChartIcon" /></li>
+    <!-- <li @click="onBubbleChart" data-test="bubble-chart"><Icon :icon="bubbleChartIcon" /></li> -->
     <li @click="onLineChart" data-test="line-chart" class="pointer"><Icon :icon="lineChartIcon" /></li>
-    <li @click="onPieChart" data-test="pie-chart"><Icon :icon="pieChartIcon" /></li>
-    <li @click="onWarning" data-test="warning"><Icon :icon="warningIcon" /></li>
-    <li @click="onDelete" data-test="delete"><Icon :icon="deleteIcon" /></li>
+    <!-- <li @click="onPieChart" data-test="pie-chart"><Icon :icon="pieChartIcon" /></li> -->
+    <li @click="onWarning" data-test="warning" class="pointer"><Icon :icon="warningIcon" /></li>
+    <!-- <li @click="onDelete" data-test="delete"><Icon :icon="deleteIcon" /></li> -->
   </ul>
 </template>
 
@@ -36,7 +36,7 @@ const onLineChart = () => {
 }
 const lineChartIcon: IIcon = {
   image: MultilineChart,
-  title: 'Line Chart'
+  tooltip: 'Graphs'
 }
 
 const onPieChart = () => {
@@ -48,11 +48,14 @@ const pieChartIcon: IIcon = {
 }
 
 const onWarning = () => {
-  console.log('warning')
+  router.push({ 
+    name: 'Nodes', 
+    params: { id: props.node.id } 
+  })
 }
 const warningIcon: IIcon = {
   image: markRaw(Warning),
-  title: 'Warning'
+  tooltip: 'Events/Alarms'
 }
 
 const onDelete = () => {
@@ -70,7 +73,6 @@ const deleteIcon: IIcon = {
 ul.icon-action-list {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   gap: 0.2rem;
   > li {
     padding: var(variables.$spacing-xxs);

--- a/ui/src/components/Inventory/MonitoredNodesTabContent.vue
+++ b/ui/src/components/Inventory/MonitoredNodesTabContent.vue
@@ -43,7 +43,7 @@ ul {
   flex-flow: row wrap;
   gap: 1rem;
   > li {
-    padding: var(variables.$spacing-l) var(variables.$spacing-xxl) var(variables.$spacing-l) var(variables.$spacing-xxl);
+    padding: var(variables.$spacing-l) var(variables.$spacing-xxl);
     border: 1px solid var(variables.$secondary-text-on-surface); 
     border-radius: 10px;
     border-left: 10px solid var(variables.$secondary-text-on-surface); // TODO set color dynamically to the node's status

--- a/ui/src/components/Inventory/MonitoredNodesTabContent.vue
+++ b/ui/src/components/Inventory/MonitoredNodesTabContent.vue
@@ -43,7 +43,7 @@ ul {
   flex-flow: row wrap;
   gap: 1rem;
   > li {
-    padding: var(variables.$spacing-l);
+    padding: var(variables.$spacing-l) var(variables.$spacing-xxl) var(variables.$spacing-l) var(variables.$spacing-xxl);
     border: 1px solid var(variables.$secondary-text-on-surface); 
     border-radius: 10px;
     border-left: 10px solid var(variables.$secondary-text-on-surface); // TODO set color dynamically to the node's status

--- a/ui/src/store/Queries/inventoryQueries.ts
+++ b/ui/src/store/Queries/inventoryQueries.ts
@@ -38,7 +38,7 @@ export const useInventoryQueries = defineStore('inventoryQueries', () => {
 
         if(data.value && !isFetching.value) {
           const [res] = data.value.nodeLatency?.data?.result as TsResult[]
-          const [uptime, latency] = res?.value || [] as number[] | string[] | undefined[]
+          const [, latency] = res?.value || [] as number[] | string[] | undefined[]
           const { location: nodeLocation } = location as Location
           const [{ ipAddress }] = ipInterfaces as IpInterface[]
         
@@ -51,13 +51,6 @@ export const useInventoryQueries = defineStore('inventoryQueries', () => {
                 type: 'latency',
                 label: 'Latency',
                 timestamp: latency,
-                status: ''
-              },
-              {
-                type: 'uptime',
-                label: 'Uptime',
-                timestamp: uptime,
-                timeUnit: TimeUnit.MSecs,
                 status: ''
               },
               {

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -32,4 +32,5 @@ export declare type fncArgVoid = (...args: unknown[]) => void;
 export interface IIcon {
   image: any,
   title?: string
+  tooltip?: string
 }

--- a/ui/tests/Inventory/iconActionList.test.ts
+++ b/ui/tests/Inventory/iconActionList.test.ts
@@ -14,11 +14,11 @@ describe('Inventory node icon action list', () => {
   })
 
   const actionList = [
-    'bubble-chart',
+    // 'bubble-chart',
     'line-chart',
-    'pie-chart',
+    // 'pie-chart',
     'warning',
-    'delete'
+    // 'delete'
   ]
   it.each(actionList)('should have "%s" action icon', (icon) => {
     expect(wrapper.get(`[data-test="${icon}"]`).exists()).toBe(true)


### PR DESCRIPTION
## Description
Adds link from inventory card to the node status page
Removes uptime from card as that will not be available
Removes other action items that don't do anything for now (as per meeting convo)
Adds optional tooltip for Icon component

![screenshot-localhost_3006-2022 12 09-14_32_06](https://user-images.githubusercontent.com/8680122/206784112-b073ed05-5d67-4a56-8beb-1fd76834632f.png)


## Jira link(s)
- https://issues.opennms.org/browse/HS-643

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
