### PR TITLE
HS-611 Further work on tenant-id handling updates

### DIFF
--- a/inventory/src/main/java/org/opennms/horizon/inventory/config/MinionGatewayGrpcClientConfig.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/config/MinionGatewayGrpcClientConfig.java
@@ -2,10 +2,8 @@ package org.opennms.horizon.inventory.config;
 
 import org.opennms.horizon.inventory.component.MinionRpcClient;
 import org.opennms.horizon.inventory.exception.InventoryRuntimeException;
-import org.opennms.horizon.inventory.grpc.TenantIdClientInterceptor;
 import org.opennms.horizon.inventory.grpc.TenantLookup;
 import org.opennms.horizon.inventory.service.taskset.publisher.GrpcTaskSetPublisher;
-import org.opennms.taskset.service.contract.TaskSetServiceGrpc;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +15,8 @@ import org.springframework.context.annotation.Lazy;
 
 @Configuration
 public class MinionGatewayGrpcClientConfig {
+
+    public static final String MINION_GATEWAY_GRPC_CHANNEL = "minion-gateway";
 
     @Value("${grpc.client.minion-gateway.host:localhost}")
     private String host;
@@ -30,7 +30,7 @@ public class MinionGatewayGrpcClientConfig {
     @Value("${grpc.client.minion-gateway.maxMessageSize:10485760}")
     private int maxMessageSize;
 
-    @Bean(name = "minion-gateway")
+    @Bean(name = MINION_GATEWAY_GRPC_CHANNEL)
     public ManagedChannel createGrpcChannel() {
         NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(host, port)
             .keepAliveWithoutCalls(true)
@@ -46,13 +46,13 @@ public class MinionGatewayGrpcClientConfig {
         return channel;
     }
 
-    @Bean(initMethod = "init")
-    public GrpcTaskSetPublisher taskSetPublisher(@Qualifier("minion-gateway") ManagedChannel channel, @Lazy TenantLookup tenantLookup) {
+    @Bean(initMethod = "init", name = GrpcTaskSetPublisher.TASK_SET_PUBLISH_BEAN_NAME)
+    public GrpcTaskSetPublisher taskSetPublisher(@Qualifier(MINION_GATEWAY_GRPC_CHANNEL) ManagedChannel channel, @Lazy TenantLookup tenantLookup) {
         return new GrpcTaskSetPublisher(channel, tenantLookup);
     }
 
     @Bean(initMethod = "init", destroyMethod = "shutdown")
-    public MinionRpcClient createMinionRpcClient(@Qualifier("minion-gateway") ManagedChannel channel, TenantLookup tenantLookup) {
+    public MinionRpcClient createMinionRpcClient(@Qualifier(MINION_GATEWAY_GRPC_CHANNEL) ManagedChannel channel, TenantLookup tenantLookup) {
         return new MinionRpcClient(channel, tenantLookup);
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
@@ -28,25 +28,36 @@
 
 package org.opennms.horizon.inventory.service.taskset.publisher;
 
-import io.grpc.Metadata;
-import io.grpc.stub.MetadataUtils;
-import lombok.RequiredArgsConstructor;
+import io.grpc.Context;
+import io.grpc.ManagedChannel;
+import org.opennms.horizon.inventory.Constants;
+import org.opennms.horizon.inventory.grpc.TenantIdClientInterceptor;
+import org.opennms.horizon.inventory.grpc.TenantLookup;
 import org.opennms.taskset.contract.TaskSet;
 import org.opennms.taskset.service.api.TaskSetPublisher;
 import org.opennms.taskset.service.contract.PublishTaskSetRequest;
 import org.opennms.taskset.service.contract.PublishTaskSetResponse;
 import org.opennms.taskset.service.contract.TaskSetServiceGrpc;
+import org.opennms.taskset.service.contract.TaskSetServiceGrpc.TaskSetServiceBlockingStub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
-@Component
-@RequiredArgsConstructor
 public class GrpcTaskSetPublisher implements TaskSetPublisher {
     private static final Logger log = LoggerFactory.getLogger(GrpcTaskSetPublisher.class);
-    private final TaskSetServiceGrpc.TaskSetServiceBlockingStub taskSetServiceStub;
+    private final ManagedChannel channel;
+    private final TenantLookup tenantLookup;
 
-    private static final Metadata.Key<String> HEADER_KEY = Metadata.Key.of("tenant-id", Metadata.ASCII_STRING_MARSHALLER);
+    private TaskSetServiceBlockingStub taskSetServiceStub;
+
+    public GrpcTaskSetPublisher(ManagedChannel channel, TenantLookup tenantLookup) {
+        this.channel = channel;
+        this.tenantLookup = tenantLookup;
+    }
+
+    private void init() {
+        taskSetServiceStub = TaskSetServiceGrpc.newBlockingStub(channel)
+            .withInterceptors(new TenantIdClientInterceptor(tenantLookup));
+    }
 
     @Override
     public void publishTaskSet(String tenantId, String location, TaskSet taskSet) {
@@ -57,11 +68,9 @@ public class GrpcTaskSetPublisher implements TaskSetPublisher {
                     .setTaskSet(taskSet)
                     .build();
 
-            Metadata metadata = new Metadata();
-            metadata.put(HEADER_KEY, tenantId);
-
-            PublishTaskSetResponse response =
-                taskSetServiceStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata)).publishTaskSet(request);
+            PublishTaskSetResponse response = Context.current().withValue(Constants.TENANT_ID_CONTEXT_KEY, tenantId).call(() ->
+                taskSetServiceStub.publishTaskSet(request)
+            );
 
             log.debug("Publish task set complete: location={}, response={}", location, response);
         } catch (Exception e) {

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/taskset/publisher/GrpcTaskSetPublisher.java
@@ -43,6 +43,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GrpcTaskSetPublisher implements TaskSetPublisher {
+
+    public static final String TASK_SET_PUBLISH_BEAN_NAME = "taskSetServiceBlockingStub";
     private static final Logger log = LoggerFactory.getLogger(GrpcTaskSetPublisher.class);
     private final ManagedChannel channel;
     private final TenantLookup tenantLookup;

--- a/inventory/src/test/java/org/opennms/horizon/inventory/TestConstants.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/TestConstants.java
@@ -25,21 +25,10 @@
  *     http://www.opennms.org/
  *     http://www.opennms.com/
  *******************************************************************************/
-
 package org.opennms.horizon.inventory;
 
-import io.grpc.Context;
-import io.grpc.Metadata;
+public interface TestConstants {
+    String PRIMARY_TENANT_ID = "test-tenant";
+    String SECONDARY_TENANT_ID = "another-tenant";
 
-public interface Constants {
-    String TENANT_ID_KEY = "tenant-id";
-    String DEFAULT_TENANT_ID = "opennms-prime";
-    String DEFAULT_LOCATION = "Default";
-    Metadata.Key<String> AUTHORIZATION_METADATA_KEY = Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
-    Metadata.Key<String> TENANT_ID_REQUEST_KEY = Metadata.Key.of(TENANT_ID_KEY, Metadata.ASCII_STRING_MARSHALLER);
-    Context.Key<String> TENANT_ID_CONTEXT_KEY = Context.key(TENANT_ID_KEY);
-
-    // TODO: Remove this once we have inter-service authentication in place
-    Metadata.Key<String> AUTHORIZATION_BYPASS_KEY = Metadata.Key.of("Bypass-Authorization", Metadata.ASCII_STRING_MARSHALLER);
-    Metadata.Key<String> TENANT_ID_BYPASS_KEY = Metadata.Key.of("Bypass-Tenant-ID", Metadata.ASCII_STRING_MARSHALLER);
 }

--- a/metrics-processor/src/main/java/org/opennms/horizon/tsdata/Constants.java
+++ b/metrics-processor/src/main/java/org/opennms/horizon/tsdata/Constants.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.horizon.tsdata;
+
+public interface Constants {
+    String TENANT_ID_KEY = "tenant-id";
+    String DEFAULT_TENANT_ID = "opennms-prime";
+    String DEFAULT_LOCATION = "Default";
+}

--- a/metrics-processor/src/main/java/org/opennms/horizon/tsdata/TSDataProcessor.java
+++ b/metrics-processor/src/main/java/org/opennms/horizon/tsdata/TSDataProcessor.java
@@ -31,6 +31,7 @@ package org.opennms.horizon.tsdata;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -66,6 +67,7 @@ public class TSDataProcessor {
     private static final String METRICS_NAME_RESPONSE = "response_time";
 
     private static final String[] MONITOR_METRICS_LABEL_NAMES = {
+        "tenant_id",
         "instance",
         "location",
         "system_id",
@@ -82,6 +84,7 @@ public class TSDataProcessor {
     //headers for future use.
     @KafkaListener(topics = "${kafka.topics}", concurrency = "1")
     public void consume(@Payload byte[] data, @Headers Map<String, Object> headers) {
+        String tenantId = getTenantId(headers);
         try {
             TaskSetResults results = TaskSetResults.parseFrom(data);
             results.getResultsList().forEach(result -> CompletableFuture.supplyAsync(() -> {
@@ -89,13 +92,13 @@ public class TSDataProcessor {
                     if (result != null) {
                         log.info("Processing task set result {}", result);
                         if (result.hasMonitorResponse()) {
-                            processMonitorResponse(result);
+                            processMonitorResponse(tenantId, result);
                         } else if (result.hasDetectorResponse()) {
                             DetectorResponse detectorResponse = result.getDetectorResponse();
                             // TBD: how to process?
                             log.info("Have detector response: task-id={}; detected={}", result.getId(), detectorResponse.getDetected());
                         } else if(result.hasCollectorResponse()) {
-                            processCollectorResponse(result);
+                            processCollectorResponse(tenantId, result);
                         }
                     } else {
                         log.warn("Task result appears to be missing the echo response details with results {}", results);
@@ -111,9 +114,9 @@ public class TSDataProcessor {
         }
     }
 
-    private void processMonitorResponse(TaskResult result) {
+    private void processMonitorResponse(String tenantId, TaskResult result) {
         MonitorResponse response = result.getMonitorResponse();
-        String[] labelValues = {response.getIpAddress(), result.getLocation(), result.getSystemId(), response.getMonitorType().name(), String.valueOf(response.getNodeId())};
+        String[] labelValues = {tenantId, response.getIpAddress(), result.getLocation(), result.getSystemId(), response.getMonitorType().name(), String.valueOf(response.getNodeId())};
         Gauge gauge = getGaugeFrom(METRICS_NAME_RESPONSE, "Monitor round trip response time", METRICS_UNIT_MS);
         gauge.labels(labelValues).set(response.getResponseTimeMs());
         Map<String, String> labels = new HashMap<>();
@@ -147,9 +150,9 @@ public class TSDataProcessor {
         });
     }
 
-    private void processCollectorResponse(TaskResult result) {
+    private void processCollectorResponse(String tenantId, TaskResult result) {
         CollectorResponse response = result.getCollectorResponse();
-        String[] labelValues = {response.getIpAddress(), result.getLocation(), result.getSystemId(),
+        String[] labelValues = {tenantId, response.getIpAddress(), result.getLocation(), result.getSystemId(),
             response.getMonitorType().name(), String.valueOf(response.getNodeId())};
         if (response.hasResult() && response.getMonitorType().equals(MonitorType.SNMP)) {
             Any collectorMetric = response.getResult();
@@ -191,4 +194,19 @@ public class TSDataProcessor {
         pushAdapter.pushMetrics(collectorRegistry, labels);
 
     }
+
+    private String getTenantId(Map<String, Object> headers) {
+        return Optional.ofNullable(headers.get("tenant-id"))
+            .map(tenantId -> {
+                if (tenantId instanceof byte[]) {
+                    return new String((byte[]) tenantId);
+                }
+                if (tenantId instanceof String) {
+                    return (String) tenantId;
+                }
+                return "" + tenantId;
+            })
+            .orElseThrow(() -> new RuntimeException("Could not determine tenant id"));
+    }
+
 }

--- a/minion-gateway/ignite-detector/server/src/main/java/org/opennms/miniongateway/detector/server/IgniteRpcRequestDispatcher.java
+++ b/minion-gateway/ignite-detector/server/src/main/java/org/opennms/miniongateway/detector/server/IgniteRpcRequestDispatcher.java
@@ -6,6 +6,6 @@ import org.opennms.cloud.grpc.minion.RpcResponseProto;
 
 public interface IgniteRpcRequestDispatcher {
 
-    CompletableFuture<RpcResponseProto> execute(RpcRequestProto request);
+    CompletableFuture<RpcResponseProto> execute(String tenantId, RpcRequestProto request);
 
 }

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/OpennmsGrpcServer.java
@@ -318,8 +318,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     }
 
     @Override
-    public CompletableFuture<RpcResponseProto> dispatch(String location, RpcRequestProto request) {
-        String tenantId = tenantIDGrpcServerInterceptor.readCurrentContextTenantId();
+    public CompletableFuture<RpcResponseProto> dispatch(String tenantId, String location, RpcRequestProto request) {
         StreamObserver<RpcRequestProto> rpcHandler = rpcConnectionTracker.lookupByLocationRoundRobin(tenantId, location);
         if (rpcHandler == null) {
             return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown location " + location));
@@ -328,8 +327,7 @@ public class OpennmsGrpcServer extends AbstractMessageConsumerManager implements
     }
 
     @Override
-    public CompletableFuture<RpcResponseProto> dispatch(String location, String systemId, RpcRequestProto request) {
-        String tenantId = tenantIDGrpcServerInterceptor.readCurrentContextTenantId();
+    public CompletableFuture<RpcResponseProto> dispatch(String tenantId, String location, String systemId, RpcRequestProto request) {
         StreamObserver<RpcRequestProto> rpcHandler = rpcConnectionTracker.lookupByMinionId(tenantId, systemId);
         if (rpcHandler == null) {
             return CompletableFuture.failedFuture(new IllegalArgumentException("Unknown system id " + systemId));

--- a/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/RpcRequestDispatcher.java
+++ b/minion-gateway/ipc-grpc-server/src/main/java/org/opennms/horizon/shared/ipc/grpc/server/manager/RpcRequestDispatcher.java
@@ -12,7 +12,7 @@ import org.opennms.cloud.grpc.minion.RpcResponseProto;
  */
 public interface RpcRequestDispatcher {
 
-    CompletableFuture<RpcResponseProto> dispatch(String location, RpcRequestProto request);
-    CompletableFuture<RpcResponseProto> dispatch(String location, String systemId, RpcRequestProto request);
+    CompletableFuture<RpcResponseProto> dispatch(String tenant, String location, RpcRequestProto request);
+    CompletableFuture<RpcResponseProto> dispatch(String tenant, String location, String systemId, RpcRequestProto request);
 
 }

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/grpc/server/GrpcServerConfig.java
@@ -87,8 +87,9 @@ public class GrpcServerConfig {
     public TaskSetTwinMessageProcessor stubCloudToMinionMessageProcessor(
         @Qualifier("taskSetPublisher") TaskSetPublisher publisher,
         @Qualifier("taskSetForwarder") TaskSetForwarder forwarder,
-        GrpcTwinPublisher grpcTwinPublisher) {
-        return new TaskSetTwinMessageProcessor(publisher, forwarder, grpcTwinPublisher);
+        GrpcTwinPublisher grpcTwinPublisher,
+        TenantIDGrpcServerInterceptor tenantIDGrpcServerInterceptor) {
+        return new TaskSetTwinMessageProcessor(publisher, forwarder, grpcTwinPublisher, tenantIDGrpcServerInterceptor);
     }
 
     @Bean

--- a/minion-gateway/main/src/main/java/org/opennms/miniongateway/ignite/LocalIgniteRpcRequestDispatcher.java
+++ b/minion-gateway/main/src/main/java/org/opennms/miniongateway/ignite/LocalIgniteRpcRequestDispatcher.java
@@ -15,11 +15,11 @@ public class LocalIgniteRpcRequestDispatcher implements IgniteRpcRequestDispatch
     }
 
     @Override
-    public CompletableFuture<RpcResponseProto> execute(RpcRequestProto request) {
+    public CompletableFuture<RpcResponseProto> execute(String tenantId, RpcRequestProto request) {
         if (request.getSystemId().isBlank()) {
-            return rpcRequestDispatcher.dispatch(request.getLocation(), request);
+            return rpcRequestDispatcher.dispatch(tenantId, request.getLocation(), request);
         }
-        return rpcRequestDispatcher.dispatch(request.getLocation(), request.getSystemId(), request);
+        return rpcRequestDispatcher.dispatch(tenantId, request.getLocation(), request.getSystemId(), request);
     }
 
 }

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -83,6 +83,11 @@
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+            <version>10.3</version>
+        </dependency>
 		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/rest-server/src/main/java/org/opennms/horizon/server/config/ConfigurationUtil.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/config/ConfigurationUtil.java
@@ -32,6 +32,7 @@ import org.opennms.horizon.server.service.gateway.NotificationGateway;
 import org.opennms.horizon.server.service.gateway.PlatformGateway;
 import org.opennms.horizon.server.service.grpc.EventsClient;
 import org.opennms.horizon.server.service.grpc.InventoryClient;
+import org.opennms.horizon.server.utils.JWTValidator;
 import org.opennms.horizon.server.utils.ServerHeaderUtil;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -56,8 +57,8 @@ public class ConfigurationUtil {
     private String eventsGrpcAddress;
 
     @Bean
-    public ServerHeaderUtil createHeaderUtil() {
-        return new ServerHeaderUtil();
+    public ServerHeaderUtil createHeaderUtil(JWTValidator validator) {
+        return new ServerHeaderUtil(validator);
     }
 
     @Bean

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/PrometheusTSDBServiceImpl.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/PrometheusTSDBServiceImpl.java
@@ -28,10 +28,17 @@
 
 package org.opennms.horizon.server.service;
 
+import io.leangen.graphql.annotations.GraphQLEnvironment;
+import io.leangen.graphql.execution.ResolutionEnvironment;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import java.util.Optional;
 import org.opennms.horizon.server.model.TimeRangeUnit;
 import org.opennms.horizon.server.model.TimeSeriesQueryResult;
+import org.opennms.horizon.server.utils.ServerHeaderUtil;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -48,9 +55,12 @@ import reactor.core.publisher.Mono;
 @Service
 public class PrometheusTSDBServiceImpl {
     private static final String QUERY_TEMPLATE = "query=%s";
+
+    private final ServerHeaderUtil headerUtil;
     private final WebClient webClient;
 
-    public PrometheusTSDBServiceImpl(@Value("${tsdb.url}") String tsdbURL) {
+    public PrometheusTSDBServiceImpl(ServerHeaderUtil headerUtil, @Value("${tsdb.url}") String tsdbURL) {
+        this.headerUtil = headerUtil;
         webClient = WebClient.builder()
             .baseUrl(tsdbURL)
             .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
@@ -59,8 +69,13 @@ public class PrometheusTSDBServiceImpl {
     }
 
     @GraphQLQuery
-    public Mono<TimeSeriesQueryResult> getMetric(String name, Map<String, String> labels, Integer timeRange, TimeRangeUnit timeRangeUnit) {
-        String queryString = generatePayloadString(name, labels);
+    public Mono<TimeSeriesQueryResult> getMetric(@GraphQLEnvironment ResolutionEnvironment env, String name, Map<String, String> labels, Integer timeRange, TimeRangeUnit timeRangeUnit) {
+        Map<String, String> metricLabels = Optional.ofNullable(labels)
+            .map(HashMap::new)
+            .orElseGet(HashMap::new);
+        // override value in case if it was in incoming values
+        metricLabels.put("tenant_id", headerUtil.extractTenant(env));
+        String queryString = generatePayloadString(name, metricLabels);
         if(timeRange != null && timeRangeUnit != null) {
             queryString += "[" + timeRange + timeRangeUnit.value + "]";
         }
@@ -72,19 +87,10 @@ public class PrometheusTSDBServiceImpl {
 
     private String generatePayloadString(String name, Map<String, String> labels) {
         String queryString = name;
-        if (labels != null && labels.size() > 0) {
-            StringBuilder filterStr = new StringBuilder();
-            String filterTmp = "%s=\"%s\"";
-            for (Map.Entry<String, String> entry : labels.entrySet()) {
-                if (filterStr.length() > 0) {
-                    filterStr.append(",");
-                }
-                filterStr.append(String.format(filterTmp, entry.getKey(), entry.getValue()));
-            }
-            filterStr.insert(0, "{");
-            filterStr.append("}");
-            queryString += filterStr;
-        }
+        String filterStr = labels.entrySet().stream()
+            .map(entry -> entry.getKey() + "=\"" + entry.getValue() + "\"")
+            .reduce("", (left, right) -> left + "," + right);
+        queryString += '{' + filterStr + '}';
         return String.format(QUERY_TEMPLATE, queryString);
     }
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/PrometheusTSDBServiceImpl.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/PrometheusTSDBServiceImpl.java
@@ -89,7 +89,7 @@ public class PrometheusTSDBServiceImpl {
         String queryString = name;
         String filterStr = labels.entrySet().stream()
             .map(entry -> entry.getKey() + "=\"" + entry.getValue() + "\"")
-            .reduce("", (left, right) -> left + "," + right);
+            .reduce((left, right) -> left + "," + right).orElse("");
         queryString += '{' + filterStr + '}';
         return String.format(QUERY_TEMPLATE, queryString);
     }

--- a/rest-server/src/main/java/org/opennms/horizon/server/utils/JWTValidator.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/utils/JWTValidator.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+package org.opennms.horizon.server.utils;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import java.net.URL;
+import java.text.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JWTValidator {
+
+    private final DefaultJWTProcessor<SecurityContext> jwtProcessor;
+
+    public JWTValidator(@Value("${keycloak.url}") String keycloakUrl, @Value("${keycloak.realm}") String realm,
+        @Value("${keycloak.signatureAlgorithm}") String signatureAlgorithm) throws Exception {
+        RemoteJWKSet jwkSet = new RemoteJWKSet<>(new URL(keycloakUrl + "/realms/" + realm + "/protocol/openid-connect/certs"));
+        JWSVerificationKeySelector<SecurityContext> jwsKeySelector = new JWSVerificationKeySelector<>(JWSAlgorithm.parse(signatureAlgorithm), jwkSet);
+
+        jwtProcessor = new DefaultJWTProcessor<>();
+        jwtProcessor.setJWSKeySelector(jwsKeySelector);
+        jwtProcessor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<>());
+    }
+
+    public void validate(String jwt) throws BadJOSEException, ParseException, JOSEException {
+        jwtProcessor.process(jwt, null);
+    }
+}

--- a/rest-server/src/main/java/org/opennms/horizon/server/utils/ServerHeaderUtil.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/utils/ServerHeaderUtil.java
@@ -44,8 +44,32 @@ import io.leangen.graphql.util.ContextUtils;
 public class ServerHeaderUtil {
 
     private static final String DEFAULT_TENANT = "opennms-prime";
+    private static final String TENANT_ID_CLAIM_NAME = "tenant-id";
+    private JWTValidator validator;
+
+    public ServerHeaderUtil(JWTValidator validator) {
+        this.validator = validator;
+    }
 
     public String getAuthHeader(ResolutionEnvironment env) {
+        String authHeader = retrieveAuthHeader(env);
+        try {
+            if (authHeader != null) {
+                // return token only if its valid
+                validator.validate(authHeader.substring(7));
+                return authHeader;
+            }
+            return null;
+        } catch (Exception e) {
+            throw new RuntimeException("Invalid token", e);
+        }
+    }
+
+    public String extractTenant(ResolutionEnvironment env) {
+        String header = getAuthHeader(env);
+        return header != null ? parseHeader(header) : "opennms-prime";
+    }
+    private String retrieveAuthHeader(ResolutionEnvironment env) {
         GraphQLContext graphQLContext = env.dataFetchingEnvironment.getContext();
         DefaultGlobalContext context = (DefaultGlobalContext) ContextUtils.unwrapContext(graphQLContext);
         ServerWebExchange webExchange = (ServerWebExchange) context.getNativeRequest();
@@ -54,11 +78,10 @@ public class ServerHeaderUtil {
         return authHeaders != null? authHeaders.get(0): null;
     }
 
-    public String extractTenant(ResolutionEnvironment env) {
-        String header = getAuthHeader(env);
+    private static String parseHeader(String header) {
         try {
-            SignedJWT jwt = SignedJWT.parse(header);
-            return Optional.ofNullable(jwt.getJWTClaimsSet().getStringClaim("tenant"))
+            SignedJWT jwt = SignedJWT.parse(header.substring(7));
+            return Optional.ofNullable(jwt.getJWTClaimsSet().getStringClaim(TENANT_ID_CLAIM_NAME))
                 .orElse(DEFAULT_TENANT);
         } catch (Exception e) {
             throw new RuntimeException("Could not extract tenant information", e);

--- a/rest-server/src/main/resources/application.yml
+++ b/rest-server/src/main/resources/application.yml
@@ -5,6 +5,11 @@ spring:
   jackson:
     default-property-inclusion: non_null
 
+keycloak:
+  url: http://onms-keycloak:8080/auth
+  realm: opennms
+  signatureAlgorithm: RS256
+
 # graphql
 graphql:
   spqr:

--- a/rest-server/src/test/resources/application.yml
+++ b/rest-server/src/test/resources/application.yml
@@ -7,6 +7,11 @@ horizon-stream:
 
 tsdb.url: http://localhost:59090/api/v1/query
 
+keycloak:
+  url: http://onms-keycloak:8080/auth
+  realm: opennms
+  signatureAlgorithm: RS256
+
 grpc:
   url:
     inventory: localhost:29065

--- a/shared-lib/task-set-service/api/src/main/java/org/opennms/taskset/service/api/TaskSetForwarder.java
+++ b/shared-lib/task-set-service/api/src/main/java/org/opennms/taskset/service/api/TaskSetForwarder.java
@@ -10,7 +10,7 @@ public interface TaskSetForwarder {
      * @param location
      * @param listener
      */
-    void addListener(String location, TaskSetListener listener);
+    void addListener(String tenantId, String location, TaskSetListener listener);
 
     /**
      * Remove a listener that was added with addListener().  Note that listeners are tracked by their system identity,
@@ -19,5 +19,5 @@ public interface TaskSetForwarder {
      * @param location
      * @param listener
      */
-    void removeListener(String location, TaskSetListener listener);
+    void removeListener(String tenantId, String location, TaskSetListener listener);
 }


### PR DESCRIPTION
## Description
(stealing existing jira id, probably require re-wording) This PR is result of testing I made with minion with non-standard tenant-id.
1) Propagation of tenant-id to metrics labels
2) Inventory service tenant-id header injection for its clients
3) Basic validation of auth token in rest-server (avoid re-use of expired tokens)
4) Remove use of grpc-tenant interceptor for internal minion gateway rpc calls initiated from ignite job.

## Jira link(s)
https://issues.opennms.org/browse/HS-611

## Flagged for review

## Checklist
* [x] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [x] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
