### PR TITLE
HS-669: Errors while loading Node Inventory page

### DIFF
--- a/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcNodeService.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/GrpcNodeService.java
@@ -87,7 +87,6 @@ public class GrpcNodeService {
 
     @GraphQLQuery
     public Mono<NodeStatus> getNodeStatus(@GraphQLArgument(name = "id") Long id, @GraphQLEnvironment ResolutionEnvironment env) {
-        boolean status = nodeStatusService.getNodeStatus(id, ICMP_MONITOR_TYPE, env);
-        return Mono.just(new NodeStatus(id, status));
+        return nodeStatusService.getNodeStatus(id, ICMP_MONITOR_TYPE, env);
     }
 }

--- a/rest-server/src/main/java/org/opennms/horizon/server/service/NodeStatusService.java
+++ b/rest-server/src/main/java/org/opennms/horizon/server/service/NodeStatusService.java
@@ -35,6 +35,7 @@ import org.opennms.horizon.inventory.dto.NodeDTO;
 import org.opennms.horizon.server.model.TSResult;
 import org.opennms.horizon.server.model.TimeRangeUnit;
 import org.opennms.horizon.server.model.TimeSeriesQueryResult;
+import org.opennms.horizon.server.model.status.NodeStatus;
 import org.opennms.horizon.server.service.grpc.InventoryClient;
 import org.opennms.horizon.server.utils.ServerHeaderUtil;
 import org.springframework.stereotype.Service;
@@ -43,9 +44,6 @@ import reactor.core.publisher.Mono;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static java.util.Objects.isNull;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -58,12 +56,11 @@ public class NodeStatusService {
     private static final String NODE_ID_KEY = "node_id";
     private static final String MONITOR_KEY = "monitor";
     private static final String INSTANCE_KEY = "instance";
-    private static final long TIMEOUT_IN_SECONDS = 30L;
     private final InventoryClient client;
     private final PrometheusTSDBServiceImpl prometheusTSDBService;
     private final ServerHeaderUtil headerUtil;
 
-    public boolean getNodeStatus(long id, String monitorType, ResolutionEnvironment env) {
+    public Mono<NodeStatus> getNodeStatus(long id, String monitorType, ResolutionEnvironment env) {
         NodeDTO node = client.getNodeById(id, headerUtil.getAuthHeader(env));
 
         if (node.getIpInterfacesCount() > 0) {
@@ -71,41 +68,39 @@ public class NodeStatusService {
             IpInterfaceDTO ipInterface = node.getIpInterfaces(0);
             return getNodeStatusByInterface(id, monitorType, ipInterface, env);
         }
-        return false;
+        return Mono.just(new NodeStatus(id, false));
     }
 
-    private boolean getNodeStatusByInterface(long id, String monitorType, IpInterfaceDTO ipInterface, ResolutionEnvironment env) {
+    private Mono<NodeStatus> getNodeStatusByInterface(long id, String monitorType, IpInterfaceDTO ipInterface, ResolutionEnvironment env) {
         String ipAddress = ipInterface.getIpAddress();
 
-        TimeSeriesQueryResult result = getStatusMetric(id, ipAddress, monitorType, env);
+        return getStatusMetric(id, ipAddress, monitorType, env)
+            .map(result -> getNodeStatus(id, result));
+    }
+
+    private NodeStatus getNodeStatus(long id, TimeSeriesQueryResult result) {
         if (isNull(result)) {
-            return false;
+            return new NodeStatus(id, false);
         }
         List<TSResult> tsResults = result.getData().getResult();
 
         if (isEmpty(tsResults)) {
-            return false;
+            return new NodeStatus(id, false);
         }
 
         TSResult tsResult = tsResults.get(0);
         List<List<Double>> values = tsResult.getValues();
 
-        return !isEmpty(values);
+        return new NodeStatus(id, !isEmpty(values));
     }
 
-    private TimeSeriesQueryResult getStatusMetric(long id, String ipAddress, String monitorType, ResolutionEnvironment env) {
+    private Mono<TimeSeriesQueryResult> getStatusMetric(long id, String ipAddress, String monitorType, ResolutionEnvironment env) {
         Map<String, String> labels = new HashMap<>();
         labels.put(NODE_ID_KEY, String.valueOf(id));
         labels.put(MONITOR_KEY, monitorType);
         labels.put(INSTANCE_KEY, ipAddress);
 
-        Mono<TimeSeriesQueryResult> result = prometheusTSDBService
+        return prometheusTSDBService
             .getMetric(env, RESPONSE_TIME_METRIC, labels, TIME_RANGE_IN_SECONDS, TimeRangeUnit.SECOND);
-        try {
-            return result.toFuture().get(TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Failed to get metrics for node", e);
-        }
     }
 }


### PR DESCRIPTION
## Description
HS-669: Errors while loading Node Inventory page

Making the nested call reactive instead of performing a blocking get. The Mono did not like the nested call.

## Jira link(s)
- https://issues.opennms.org/browse/HS-669

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
