### PR TITLE
Set "trimStackTrace" to false on minion-gateway docker-it to prevent …

### DIFF
--- a/minion-gateway/docker-it/pom.xml
+++ b/minion-gateway/docker-it/pom.xml
@@ -138,6 +138,7 @@
                     <skipITs>${skipITs}</skipITs>
                     <reuseForks>true</reuseForks>
                     <useSystemClassLoader>false</useSystemClassLoader>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
…the failsafe plugin from trimming stack traces.

## Description
<!-- Describe this Pull Request, what it changes, and why it's necessary. -->

## Jira link(s)
- https://issues.opennms.org/browse/HS-xx

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
