### PR TITLE
HS-753: Asynchronously update tasks and config changes

### DIFF
--- a/inventory/pom.xml
+++ b/inventory/pom.xml
@@ -209,6 +209,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>1.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
         </dependency>

--- a/inventory/src/main/java/org/opennms/horizon/inventory/grpc/NodeGrpcService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/grpc/NodeGrpcService.java
@@ -30,6 +30,7 @@ package org.opennms.horizon.inventory.grpc;
 
 import com.google.common.base.Strings;
 import com.google.common.net.InetAddresses;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Int64Value;
 import com.google.rpc.Code;
@@ -50,10 +51,12 @@ import org.opennms.horizon.inventory.model.Node;
 import org.opennms.horizon.inventory.service.IpInterfaceService;
 import org.opennms.horizon.inventory.service.NodeService;
 import org.opennms.horizon.inventory.service.taskset.DetectorTaskSetService;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -63,19 +66,22 @@ public class NodeGrpcService extends NodeServiceGrpc.NodeServiceImplBase {
     private final NodeMapper nodeMapper;
     private final TenantLookup tenantLookup;
     private final DetectorTaskSetService taskSetService;
+    private final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat("send-taskset-for-node-%d")
+        .build();
+    private final ExecutorService executorService = Executors.newFixedThreadPool(10, threadFactory);
 
     @Override
-    @Transactional
     public void createNode(NodeCreateDTO request, StreamObserver<NodeDTO> responseObserver) {
         Optional<String> tenantId = tenantLookup.lookupTenantId(Context.current());
         boolean valid = tenantId.map(id -> validateInput(request, id, responseObserver)).orElseThrow();
 
         if (valid) {
             Node node = nodeService.createNode(request, tenantId.orElseThrow());
-
-            taskSetService.sendDetectorTasks(node);
             responseObserver.onNext(nodeMapper.modelToDTO(node));
             responseObserver.onCompleted();
+            // Asynchronously send task sets to Minion
+            executorService.execute(() -> sendTaskSetsToMinion(node));
         }
     }
 
@@ -173,5 +179,13 @@ public class NodeGrpcService extends NodeServiceGrpc.NodeServiceImplBase {
         }
 
         return valid;
+    }
+
+    private void sendTaskSetsToMinion(Node node) {
+        try {
+            taskSetService.sendDetectorTasks(node);
+        } catch (Exception e) {
+            log.error("Error while sending detector task for node with label {}", node.getNodeLabel());
+        }
     }
 }

--- a/inventory/src/main/java/org/opennms/horizon/inventory/service/ConfigUpdateService.java
+++ b/inventory/src/main/java/org/opennms/horizon/inventory/service/ConfigUpdateService.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * This file is part of OpenNMS(R).
+ *
+ * Copyright (C) 2022 The OpenNMS Group, Inc.
+ * OpenNMS(R) is Copyright (C) 1999-2022 The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is a registered trademark of The OpenNMS Group, Inc.
+ *
+ * OpenNMS(R) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * OpenNMS(R) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with OpenNMS(R).  If not, see:
+ *      http://www.gnu.org/licenses/
+ *
+ * For more information contact:
+ *     OpenNMS(R) Licensing <license@opennms.org>
+ *     http://www.opennms.org/
+ *     http://www.opennms.com/
+ *******************************************************************************/
+
+package org.opennms.horizon.inventory.service;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ConfigUpdateService {
+
+    private final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+        .setNameFormat("new-location-run-config-update-%d")
+        .build();
+    private final ExecutorService executorService = Executors.newFixedThreadPool(10, threadFactory);
+    private final TrapConfigService trapConfigService;
+
+
+    private void sendConfigUpdatesToMinion(String tenantId, String location) {
+        try {
+            trapConfigService.sendTrapConfigToMinion(tenantId, location);
+        } catch (Exception e) {
+            log.error("Exception while sending traps to Minion", e);
+        }
+    }
+
+    public void sendConfigUpdate(String tenantId, String location) {
+        executorService.execute(() -> sendConfigUpdatesToMinion(tenantId, location));
+    }
+
+}

--- a/inventory/src/test/java/org/opennms/horizon/inventory/component/NodeMonitoringManagerTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/component/NodeMonitoringManagerTest.java
@@ -28,18 +28,6 @@
 
 package org.opennms.horizon.inventory.component;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +43,19 @@ import org.opennms.horizon.inventory.service.NodeService;
 import org.opennms.horizon.inventory.service.taskset.DetectorTaskSetService;
 import org.opennms.horizon.shared.constants.GrpcConstants;
 import org.opennms.horizon.shared.events.EventConstants;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class NodeMonitoringManagerTest {
@@ -99,7 +100,7 @@ class NodeMonitoringManagerTest {
         assertThat(createDTO.getLocation()).isEqualTo(event.getLocation());
         assertThat(createDTO.getManagementIp()).isEqualTo(event.getIpAddress());
         assertThat(createDTO.getLabel()).endsWith(event.getIpAddress());
-        verify(detectorService).sendDetectorTasks(any(Node.class));
+        verify(detectorService, timeout(10000)).sendDetectorTasks(any(Node.class));
     }
 
     @Test

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcServiceTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcServiceTest.java
@@ -47,6 +47,7 @@ import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -86,8 +87,7 @@ public class NodeGrpcServiceTest {
 
         verify(obs, times(0)).onError(any());
         verify(obs).onCompleted();
-
-        verify(taskSetService, times(1)).sendDetectorTasks(any());
+        verify(taskSetService, timeout(10000).times(1)).sendDetectorTasks(any());
     }
 
     @Test

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/NodeGrpcStartupIntTest.java
@@ -28,6 +28,7 @@
 
 package org.opennms.horizon.inventory.grpc;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -43,7 +44,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
+import static com.jayway.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(properties = { "spring.liquibase.change-log=db/changelog/changelog-test.xml" })
@@ -79,7 +82,7 @@ class NodeGrpcStartupIntTest extends GrpcTestBase {
     @Test
     void testStartup() throws Exception {
         // TrapConfigService listens for ApplicationReadyEvent and sends the trap config for each location.
-        assertEquals(1, testGrpcService.getTimesCalled());
+        await().atMost(10, TimeUnit.SECONDS).untilAtomic(testGrpcService.getTimesCalled(), Matchers.is(1));
 
         org.assertj.core.api.Assertions.assertThat(testGrpcService.getRequests())
             .hasSize(1)

--- a/inventory/src/test/java/org/opennms/horizon/inventory/grpc/taskset/TestTaskSetGrpcService.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/grpc/taskset/TestTaskSetGrpcService.java
@@ -9,17 +9,18 @@ import org.opennms.taskset.service.contract.TaskSetServiceGrpc;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 @Getter
 public class TestTaskSetGrpcService extends TaskSetServiceGrpc.TaskSetServiceImplBase {
-    private int timesCalled = 0;
+    private AtomicInteger timesCalled = new AtomicInteger(0);
     private final List<PublishTaskSetRequest> requests = new ArrayList<>();
 
     @Override
     public void publishTaskSet(PublishTaskSetRequest request,
                                StreamObserver<PublishTaskSetResponse> responseObserver) {
-        this.timesCalled++;
+        this.timesCalled.incrementAndGet();
         this.requests.add(request);
         log.info("Called TestTaskSetGrpcService.publishTaskSet with request = {}", request);
         responseObserver.onNext(PublishTaskSetResponse.newBuilder().build());
@@ -27,7 +28,7 @@ public class TestTaskSetGrpcService extends TaskSetServiceGrpc.TaskSetServiceImp
     }
 
     public void reset() {
-        timesCalled = 0;
+        timesCalled.set(0);
         requests.clear();
     }
 }

--- a/inventory/src/test/java/org/opennms/horizon/inventory/service/MonitoringSystemServiceTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/service/MonitoringSystemServiceTest.java
@@ -28,16 +28,6 @@
 
 package org.opennms.horizon.inventory.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,10 +40,20 @@ import org.opennms.horizon.inventory.model.MonitoringSystem;
 import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.MonitoringSystemRepository;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 public class MonitoringSystemServiceTest {
     private MonitoringLocationRepository mockLocationRepo;
     private MonitoringSystemRepository mockMonitoringSystemRepo;
-    private TrapConfigService mockTrapConfigService;
+    private ConfigUpdateService mockConfigUpdateService;
     private MonitoringSystemService service;
 
     private MonitoringSystem testMonitoringSystem;
@@ -69,9 +69,9 @@ public class MonitoringSystemServiceTest {
     public void setUP(){
         mockLocationRepo = mock(MonitoringLocationRepository.class);
         mockMonitoringSystemRepo = mock(MonitoringSystemRepository.class);
-        mockTrapConfigService = mock(TrapConfigService.class);
+        mockConfigUpdateService = mock(ConfigUpdateService.class);
         MonitoringSystemMapper mapper = Mappers.getMapper(MonitoringSystemMapper.class);
-        service = new MonitoringSystemService(mockMonitoringSystemRepo, mockLocationRepo, mapper, mockTrapConfigService);
+        service = new MonitoringSystemService(mockMonitoringSystemRepo, mockLocationRepo, mapper, mockConfigUpdateService);
         testLocation = new MonitoringLocation();
         testLocation.setLocation(location);
         testLocation.setTenantId(tenantId);
@@ -90,7 +90,6 @@ public class MonitoringSystemServiceTest {
     public void postTest() {
         verifyNoMoreInteractions(mockLocationRepo);
         verifyNoMoreInteractions(mockMonitoringSystemRepo);
-        verifyNoMoreInteractions(mockTrapConfigService);
     }
 
     @Test
@@ -121,7 +120,6 @@ public class MonitoringSystemServiceTest {
         verify(mockMonitoringSystemRepo).save(any(MonitoringSystem.class));
         verify(mockLocationRepo).findByLocationAndTenantId(location, tenantId);
         verify(mockLocationRepo).save(any(MonitoringLocation.class));
-        verify(mockTrapConfigService).sendTrapConfigToMinion(testLocation.getTenantId(), testLocation.getLocation());
     }
 
     @Test

--- a/inventory/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/service/NodeServiceTest.java
@@ -28,17 +28,6 @@
 
 package org.opennms.horizon.inventory.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
-import java.util.Optional;
-
 import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.runner.RunWith;
@@ -56,6 +45,18 @@ import org.opennms.horizon.inventory.repository.MonitoringLocationRepository;
 import org.opennms.horizon.inventory.repository.NodeRepository;
 import org.opennms.horizon.shared.constants.GrpcConstants;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 @RunWith(MockitoJUnitRunner.class)
 public class NodeServiceTest {
 
@@ -72,7 +73,7 @@ public class NodeServiceTest {
     IpInterfaceRepository ipInterfaceRepository;
 
     @Mock
-    TrapConfigService trapConfigService;
+    ConfigUpdateService configUpdateService;
 
     @Mock
     NodeMapper mapper;
@@ -106,7 +107,7 @@ public class NodeServiceTest {
 
         verify(ipInterfaceRepository).save(any(IpInterface.class));
         verify(monitoringLocationRepository).save(any(MonitoringLocation.class));
-        verify(trapConfigService).sendTrapConfigToMinion(tenant, location);
+        verify(configUpdateService, timeout(5000)).sendConfigUpdate(tenant, location);
     }
 
     @Test
@@ -126,7 +127,7 @@ public class NodeServiceTest {
 
         verify(ipInterfaceRepository).save(any(IpInterface.class));
         verify(monitoringLocationRepository, times(0)).save(any(MonitoringLocation.class));
-        verify(trapConfigService, times(0)).sendTrapConfigToMinion(eq(tenantId), any());
+        verify(configUpdateService, timeout(5000).times(0)).sendConfigUpdate(eq(tenantId), any());
     }
 
     @Test

--- a/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseServiceIntTest.java
+++ b/inventory/src/test/java/org/opennms/horizon/inventory/service/taskset/response/DetectorResponseServiceIntTest.java
@@ -116,7 +116,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
         MonitoredServiceType relatedType = monitoredService.getMonitoredServiceType();
         assertEquals(monitoredServiceType, relatedType);
 
-        assertEquals(2, testGrpcService.getTimesCalled());
+        assertEquals(2, testGrpcService.getTimesCalled().intValue());
     }
 
     @Test
@@ -153,7 +153,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
         MonitoredServiceType relatedType = monitoredService.getMonitoredServiceType();
         assertEquals(monitoredServiceType, relatedType);
 
-        assertEquals(numberOfCalls*2, testGrpcService.getTimesCalled());
+        assertEquals(numberOfCalls*2, testGrpcService.getTimesCalled().intValue());
     }
 
     @Test
@@ -173,7 +173,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
         List<MonitoredService> monitoredServices = monitoredServiceRepository.findAll();
         assertEquals(0, monitoredServices.size());
 
-        assertEquals(0, testGrpcService.getTimesCalled());
+        assertEquals(0, testGrpcService.getTimesCalled().intValue());
     }
 
     @Test
@@ -220,7 +220,7 @@ class DetectorResponseServiceIntTest extends GrpcTestBase {
             assertEquals(TEST_TENANT_ID, monitoredService.getTenantId());
         }
 
-        assertEquals(numberOfCalls*2, testGrpcService.getTimesCalled());
+        assertEquals(numberOfCalls*2, testGrpcService.getTimesCalled().intValue());
 
         List<PublishTaskSetRequest> grpcRequests = testGrpcService.getRequests();
         assertEquals(monitorTypes.length*2, grpcRequests.size());


### PR DESCRIPTION
## Description
Tasks/Config updates should be sent asynchronously while adding a Minion or a Device.
Any failure related to task/config updates shouldn't effect adding Minion/Device to the DB.

## Jira link(s)
- https://issues.opennms.org/browse/HS-753

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
