### PR TITLE
HS-785: Rename kafka topic from events-proto to events

### DIFF
--- a/alarm/src/main/resources/application.yaml
+++ b/alarm/src/main/resources/application.yaml
@@ -32,5 +32,5 @@ spring:
 
 kafka:
   topics:
-    alarm-events: "events-proto"
+    alarm-events: "events"
     new-alarms: "alarms"

--- a/alarm/src/test/resources/org/opennms/horizon/alarmservice/alarm.feature
+++ b/alarm/src/test/resources/org/opennms/horizon/alarmservice/alarm.feature
@@ -4,20 +4,20 @@ Feature: Alarm Service Basic Functionality
   Background: Configure base URLs
     Given Application Base URL in system property "application.base-url"
     Given Kafka Bootstrap URL in system property "kafka.bootstrap-servers"
-    Given Kafka topics "events-proto" "alarms"
+    Given Kafka topics "events" "alarms"
 
   Scenario: Verify when an event is received from Kafka, a new Alarm is created
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.010"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.010"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 1 |
 
   Scenario: Verify when an event is received from Kafka, a new Alarm is created
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.020"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.020"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 2 |
 
   Scenario: Verify alarm can be deleted
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.030"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.030"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 3 |
     Then Remember alarm id
@@ -30,7 +30,7 @@ Feature: Alarm Service Basic Functionality
       | totalCount == 2 |
 
   Scenario: Verify alarm can be cleared
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.040"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.040"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 3 |
     Then Send POST request to clear alarm at path "/alarms/clear"
@@ -43,7 +43,7 @@ Feature: Alarm Service Basic Functionality
     Then Verify alarm was uncleared
 
   Scenario: Verify alarm can be acknowledged and unacknowledged
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.050"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.050"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 4 |
     Then Send POST request to acknowledge alarm at path "/alarms/ack"
@@ -56,7 +56,7 @@ Feature: Alarm Service Basic Functionality
     Then Verify alarm was unacknowledged
 
   Scenario: Verify alarm severity can be set and escalated
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.060"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.060"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 5 |
     Then Send POST request to set alarm severity at path "/alarms/severity"
@@ -70,20 +70,20 @@ Feature: Alarm Service Basic Functionality
 
   Scenario: Verify alarm reduction for duplicate events
     # Generate an alarm
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.070"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.070"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 6        |
       | alarms[0].counter == 1 |
 
     # Generate a duplicate
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.070"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.070"
     Then Verify the HTTP response code is 200
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 6        |
       | alarms[5].counter == 2 |
 
   Scenario: Verify alarm memo can be updated and removed
-    Then Send Event message to Kafka at topic "events-proto" with alarm reduction key "alarm.reduction-key.080"
+    Then Send Event message to Kafka at topic "events" with alarm reduction key "alarm.reduction-key.080"
     Then send GET request to application at path "/alarms/list", with timeout 5000ms, until JSON response matches the following JSON path expressions
       | totalCount == 7 |
     Then Send PUT request to add memo at path "/alarms/memo"

--- a/events/main/src/main/resources/application.yml
+++ b/events/main/src/main/resources/application.yml
@@ -25,7 +25,7 @@ grpc:
 
 kafka:
   traps-topic: "traps"
-  events-topic: "events-proto"
+  events-topic: "events"
   internal-topic: "internal-event"
 
 keycloak:


### PR DESCRIPTION
## Description
`events-proto` name was workaround as `events` was already a kafka topic in Core.
Correcting that now since Core no longer exists.

## Jira link(s)
- https://issues.opennms.org/browse/HS-785
## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
