### PR TITLE
Use dependency io.github.resilience4j:1.7.0 in metrics-processor

### DIFF
--- a/metrics-processor/pom.xml
+++ b/metrics-processor/pom.xml
@@ -73,8 +73,8 @@
             <version>${snappy-java.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.opennms.plugin.timeseries.cortex.wrap</groupId>
-            <artifactId>resilience4j</artifactId>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-bulkhead</artifactId>
             <version>${resilience4j.version}</version>
         </dependency>
         <dependency>

--- a/metrics-processor/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
+++ b/metrics-processor/src/main/java/org/opennms/timeseries/cortex/CortexTSS.java
@@ -35,8 +35,6 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.opennms.timeseries.cortex.shaded.resilience4j.bulkhead.Bulkhead;
-import org.opennms.timeseries.cortex.shaded.resilience4j.bulkhead.BulkheadConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xerial.snappy.Snappy;
@@ -44,6 +42,8 @@ import org.xerial.snappy.Snappy;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 
+import io.github.resilience4j.bulkhead.Bulkhead;
+import io.github.resilience4j.bulkhead.BulkheadConfig;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.ConnectionPool;

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -113,7 +113,7 @@
         <cron-utils.version>9.1.6</cron-utils.version>
         <eos.version>1.2.0</eos.version>
         <okhttp.version>3.14.0</okhttp.version>
-        <resilience4j.version>2.0.1</resilience4j.version>
+        <resilience4j.version>1.7.0</resilience4j.version>
         <snappy-java.version>1.1.8.4</snappy-java.version>
     </properties>
 


### PR DESCRIPTION
HS-802

## Description
Update Metrics-processor dependecy org.opennms.plugin.timeseries.cortex.wrap:resilience4j to io.github.resilience4j.

## Jira link(s)
- https://issues.opennms.org/browse/HS-802

## Flagged for review
<!-- Flag things as "needs a close look" for reviewers, if necessary. Include as much detail as possible (line numbers, concerns, and so on). -->

## Checklist
* [ ] Follows Horizon Stream's [development guidelines.](https://github.com/OpenNMS/horizon-stream/wiki/Development-Guidelines)
* [ ] Appropriate reviewer(s) have been selected.
* [ ] Jira issue(s) have been updated to "In Review".
* [ ] Includes [appropriate tests.](https://github.com/OpenNMS/horizon-stream/wiki/Test-Strategy)
* [ ] Documentation has been updated as necessary.
